### PR TITLE
Remove custom ansible

### DIFF
--- a/roles/dev-setup-rpc/tasks/main.yml
+++ b/roles/dev-setup-rpc/tasks/main.yml
@@ -21,11 +21,6 @@
   tags: rpc
   pip: requirements=~/{{rpc_repo_dir}}/requirements.txt
 
-- name: install ansible
-  shell: pip install -U .
-  args:
-    chdir: ~/ansible
-
 - name: Install turbolift
   pip:
     name: turbolift

--- a/roles/dev-setup-rpc/tasks/main.yml
+++ b/roles/dev-setup-rpc/tasks/main.yml
@@ -21,9 +21,6 @@
   tags: rpc
   pip: requirements=~/{{rpc_repo_dir}}/requirements.txt
 
-- name: clone ansible
-  shell: rm -rf ansible||:; git clone --recursive --branch jenkins https://github.com/hughsaunders/ansible
-
 - name: install ansible
   shell: pip install -U .
   args:


### PR DESCRIPTION
A custom version of ansible is used to work around issues with SSH and
apt. This means that a different version of ansible is being used for
testing than is being used by deployments.

This commit removes the custom version of ansible. The SSH connection
issues should be addressed by https://review.openstack.org/#/c/152936/15
and the apt tasks are being modified so that they use do-until loops.