### PR TITLE
Adjust user_config vars to be booleans

### DIFF
--- a/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
@@ -85,10 +85,10 @@ global_overrides:
         subnetmask: "{{ network.subnetmask }}"
 {% endif %}
 {% if network.is_container_address is defined %}
-        is_container_address: "{{ network.is_container_address }}"
+        is_container_address: {{ network.is_container_address }}
 {% endif %}
 {% if network.is_ssh_address is defined %}
-        is_ssh_address: "{{ network.is_ssh_address }}"
+        is_ssh_address: {{ network.is_ssh_address }}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
The is_container_address and is_ssh_address variables which are required
for ansible_ssh_hosts vars to be populated for containers need to be
booleans and not strings.