### PR TITLE
repo-infra_hosts needs to be added to user_config

### DIFF
--- a/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
@@ -102,6 +102,13 @@ infra_hosts:
     ip: {{ hostvars[host]["ansible_ssh_host"] }}
 {% endfor %}
 
+# User defined Repo Infrastructure Hosts, this should be a required group
+repo-infra_hosts:
+{% for host in infra %}
+  {{ host }}:
+    ip: {{ hostvars[host]["ansible_ssh_host"] }}
+{% endfor %}
+
 # User defined Network Hosts, this should be a required group
 network_hosts:
 {% for host in network %}


### PR DESCRIPTION
repo-infra_hosts stanza is required in the openstack_user_config.yml.
We need repo containers to be built and setup in order for other
services to install properly.