### PR TITLE
Adjust pwgen to run against user_secrets

### DIFF
--- a/playbooks/roles/configure-rpc-compute/tasks/main.yml
+++ b/playbooks/roles/configure-rpc-compute/tasks/main.yml
@@ -15,7 +15,7 @@
             dest=/etc/{{config_prefix}}_deploy/{{config_prefix}}_user_config.yml
 
 - name: Generate passphrases
-  command: ~/{{rpc_repo_dir}}/scripts/pw-token-gen.py --file /etc/{{config_prefix}}_deploy/user_variables.yml
+  command: ~/{{rpc_repo_dir}}/scripts/pw-token-gen.py --file /etc/{{config_prefix}}_deploy/user_secrets.yml
 
 - name: "template target.sh"
   template: src=target.sh.j2


### PR DESCRIPTION
Passwords/keys are all stored in user_secrets.yml by default, this has
changed from user_variables so we need to run the pwgen script against
the user_secrets.yml file instead of user_variables to prevent having
empty passwords which will cause failures.