### PR TITLE
Set TEMPEST_DEPLOY var to be a string not a bool

### DIFF
--- a/playbooks/commit-multinode.yml
+++ b/playbooks/commit-multinode.yml
@@ -37,7 +37,7 @@
     - role: run-script-from-os-ansible-deployment
       script_name: run-playbooks
       script_env:
-        DEPLOY_TEMPEST: yes
+        DEPLOY_TEMPEST: "yes"
 
 ## --------- [ Test with tempest ] ---------------
 - hosts: infrastructure[0]


### PR DESCRIPTION
The run-playbooks script is checking for a string, but a bool is being
passed to the script, meaning Tempest isn't deployed. This change fixes
that.