### PR TITLE
Adjust net_name in user_config.yml

### DIFF
--- a/playbooks/vars/commit-multinode.yml
+++ b/playbooks/vars/commit-multinode.yml
@@ -48,7 +48,7 @@ rpc_user_config:
           bridge: br-vlan
           container_interface: eth11
           type: flat
-          net_name: vlan
+          net_name: flat
           group_binds:
             - neutron_linuxbridge_agent
 


### PR DESCRIPTION
The flat network needs to have a net_name of "flat" in order for the
tempest play to create the public network.