### PR TITLE
Fix tagging in commit-multinode.yml

### DIFF
--- a/playbooks/commit-multinode.yml
+++ b/playbooks/commit-multinode.yml
@@ -1,12 +1,11 @@
 ---
 
 ## --------- [ Prepare Cluster ] ---------------
-- include: packages.yml
-  tags: prepare
-- include: pip.yml
-  tags: prepare
-- include: networking.yml
-  tags: prepare
+- include: packages.yml tags=prepare
+
+- include: pip.yml tags=prepare
+
+- include: networking.yml tags=prepare
 
 - hosts: all
   tasks:
@@ -15,6 +14,7 @@
         vg: "{{item.name}}"
         pvs: "{{item.device}}"
       with_items: vgs
+  tags: prepare
 
 - hosts: infrastructure[0]
   tags: prepare


### PR DESCRIPTION
There are several tasks that are not running when the prepare tag is
used because either the tag is missing or they are incorrectly tagged.

The syntax for tagging the included playbooks is incorrect, this commit
adjusts it so that they are run when the prepare tag is used.

This commit also adds the prepare tag to the task creating the vgs.