### PR TITLE
Fix user_variables template

### DIFF
--- a/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
@@ -1,4 +1,4 @@
-glance_default_store: swift
+{% raw %}glance_default_store: swift
 glance_notification_driver: noop
 glance_swift_store_auth_address: '{{ keystone_service_internalurl }}'
 glance_swift_store_container: glance_images
@@ -6,3 +6,4 @@ glance_swift_store_endpoint_type: internalURL
 glance_swift_store_key: '{{ glance_service_password }}'
 glance_swift_store_region: RegionOne
 glance_swift_store_user: 'service:glance'
+{% endraw %}


### PR DESCRIPTION
The options in user_variables are being templated and causing failures.
These vars are meant to be raw as they are vars that exist in
os-ansible-deployment.