### PR TITLE
Adjust the way we include playbooks to fix tags

### DIFF
--- a/playbooks/commit-multinode.yml
+++ b/playbooks/commit-multinode.yml
@@ -1,11 +1,28 @@
 ---
 
 ## --------- [ Prepare Cluster ] ---------------
-- include: packages.yml tags=prepare
 
-- include: pip.yml tags=prepare
+- hosts: all
+  user: root
+  vars_files:
+    - vars/packages.yml
+  roles:
+    - packages
+  tags: prepare
 
-- include: networking.yml tags=prepare
+- hosts: all
+  user: root
+  vars_files:
+    - vars/pip.yml
+  roles:
+    - pip
+  tags: prepare
+
+- hosts: all
+  user: root
+  roles:
+    - networking
+  tags: prepare
 
 - hosts: all
   tasks:


### PR DESCRIPTION
Tagging an include just passes the tag to the include requiring all
tasks to be tagged within the roles that are included.

Since the 3 includes for commit-multinode each reference only 1 role its
simpler to call that role and tag this.