### PR TITLE
Bring up network interfaces after placing config

### DIFF
--- a/playbooks/roles/networking/tasks/main.yml
+++ b/playbooks/roles/networking/tasks/main.yml
@@ -27,3 +27,6 @@
   template: src=interface.j2 dest=/etc/network/interfaces.d/{{ item.name }}.cfg owner=root group=root mode=0644
   with_items: networking
   register: result
+
+- name: Bring up new interfaces
+  command: ifup -a


### PR DESCRIPTION
We need to bring the network interfaces up after we place the config
files for these interfaces. This used to happen as part of a reboot
which is no longer the case.