### PR TITLE
convert nightly labs to use banch-vars files

### DIFF
--- a/dockerfiles/nightly-job/job.sh
+++ b/dockerfiles/nightly-job/job.sh
@@ -71,6 +71,7 @@ then
   ansible-playbook \
     -i playbooks/inventory/$LAB \
     -e @playbooks/vars/$LAB \
+    -e @playbooks/vars/branch-vars-$targetBranch \
     playbooks/nightly-multinode.yml & wait %1
 fi
 

--- a/playbooks/vars/icehouse-nightly.yml
+++ b/playbooks/vars/icehouse-nightly.yml
@@ -1,6 +1,4 @@
 rpc_repo_dir: rpc_repo
-targetBranch: icehouse
-config_prefix: rpc
 repo_url: http://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 rpc_user_config:

--- a/playbooks/vars/juno-nightly.yml
+++ b/playbooks/vars/juno-nightly.yml
@@ -1,6 +1,4 @@
 rpc_repo_dir: rpc_repo
-targetBranch: juno
-config_prefix: rpc
 repo_url: http://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 rpc_user_config:


### PR DESCRIPTION
removed vars that are in branch-vars from nightly labs vars, added vars to play run in dockerimage

closes https://github.com/rcbops/jenkins-rpc/issues/158