### PR TITLE
Add teardown playbook

### DIFF
--- a/playbooks/teardown.yml
+++ b/playbooks/teardown.yml
@@ -1,0 +1,8 @@
+--
+- include: teardown-infrastructure-node
+- include: teardown-network-node
+- include: teardown-cinder-node
+- include: teardown-swift-node
+- include: teardown-logging-node
+- include: teardown-compute-node
+- include: cleanup-host


### PR DESCRIPTION
This playbook includes various roles for tearing down an OpenStack installation

The use-case for these playbooks is avoiding a re-kick of an environment. Rather, all installed OpenStack components and containers are removed from hosts. The end result is a relatively bare customer environment, ready for deployment.

These roles have been implemented for IAD3-LAB01 and IAD3-LAB02.