### PR TITLE
Don't expect the pw-gen to create user_secrets

### DIFF
--- a/playbooks/roles/configure-rpc-compute/tasks/main.yml
+++ b/playbooks/roles/configure-rpc-compute/tasks/main.yml
@@ -26,4 +26,3 @@
 
 - name: Generate passphrases
   command: ~/{{rpc_repo_dir}}/scripts/pw-token-gen.py --file /etc/{{config_prefix}}_deploy/user_secrets.yml
-           creates=/etc/{{config_prefix}}_deploy/user_secrets.yml


### PR DESCRIPTION
Since user_secrets already exists, expecting it to create the file will
mean it is skipped and the passwords are never populated.