### PR TITLE
Set the tempest_public_subnet_cidr appropriately

### DIFF
--- a/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
@@ -6,4 +6,5 @@ glance_swift_store_endpoint_type: internalURL
 glance_swift_store_key: '{{ glance_service_password }}'
 glance_swift_store_region: RegionOne
 glance_swift_store_user: 'service:glance'
+tempest_public_subnet_cidr: '172.29.248.0/22'
 {% endraw %}

--- a/playbooks/vars/commit-multinode.yml
+++ b/playbooks/vars/commit-multinode.yml
@@ -3,7 +3,7 @@ repo_url: http://rpc-repo.rackspace.com
 rpc_user_config:
     container_cidr: 172.29.236.0/22
     tunnel_cidr:  172.29.240.0/22
-    storage_cidr:  172.29.248.0/22
+    storage_cidr:  172.29.244.0/22
     used_ips:
         - 172.29.236.1
         - 172.29.236.2
@@ -23,10 +23,6 @@ rpc_user_config:
         - 172.29.244.4
         - 172.29.244.5
 
-        - "172.29.236.1,172.29.236.15"
-        - "172.29.236.83,172.29.236.127"
-        - "172.29.240.83,172.29.240.127"
-        - "172.29.248.83,172.29.248.127"
     internal_lb_vip_address: 172.29.236.1
     external_lb_vip_address: "{{hostvars[groups['infrastructure'][0]]['ansible_ssh_host']}}"
     tunnel_bridge: br-vxlan


### PR DESCRIPTION
We already have a br-vlan, we should set the tempest_public_subnet_cidr
to utilise this IP range.
Additionally, we can clean up some of the "used_ips" in the
commit_multinode vars, and adjust a typo on the storage_netowrk which
was set to use the same range as br-vlan.