### PR TITLE
Remove branch-vars

### DIFF
--- a/dockerfiles/nightly-job/job.sh
+++ b/dockerfiles/nightly-job/job.sh
@@ -55,43 +55,21 @@ cleanup() {
 set_trap cleanup INT TERM ERR
 
 # Clone jenkins-rpc repo
-git clone git@github.com:rcbops/jenkins-rpc.git & wait %1
+git clone ${JENKINS_RPC_URL:-git@github.com:rcbops/jenkins-rpc.git} & wait %1
 
-if [[ $BUILD == "branch" ]]
-then
-  # Move into jenkins-rpc
-  pushd jenkins-rpc
-  git checkout $RELEASE
- 
-  # Set color and buffer
-  export PYTHONUNBUFFERED=1
-  export ANSIBLE_FORCE_COLOR=1
+# Move into jenkins-rpc
+pushd jenkins-rpc
+git checkout $JENKINS_RPC_BRANCH
 
-  # Preconfigure lab / build RPC / test RPC
-  ansible-playbook \
-    -i playbooks/inventory/$LAB \
-    -e @playbooks/vars/$LAB.yml \
-    -e @playbooks/vars/branch-vars-$RELEASE.yml \
-    playbooks/nightly-multinode.yml & wait %1
-elif [[ $BUILD == "tag" ]]
-then
-  # Move into jenkins-rpc
-  pushd jenkins-rpc
-  git checkout $RELEASE
- 
-  # Set color and buffer
-  export PYTHONUNBUFFERED=1
-  export ANSIBLE_FORCE_COLOR=1
+# Set color and buffer
+export PYTHONUNBUFFERED=1
+export ANSIBLE_FORCE_COLOR=1
 
-  # Preconfigure lab / build RPC / test RPC
-  ansible-playbook \
-    -i playbooks/inventory/$LAB \
-    -e @playbooks/vars/$LAB.yml \
-    -e @playbooks/vars/branch-vars-$RELEASE.yml \
-    -e LATEST_TAG=true \
-    playbooks/nightly-multinode.yml & wait %1
-
-fi
-
+# Preconfigure lab / build RPC / test RPC
+ansible-playbook \
+  -i playbooks/inventory/$LAB \
+  -e @playbooks/vars/$LAB.yml \
+  -e os_ansible_branch=${OS_ANSIBLE_BRANCH}
+  playbooks/nightly-multinode.yml & wait %1
 # Exit cleanly
 exit 0

--- a/playbooks/roles/setup-git/tasks/main.yml
+++ b/playbooks/roles/setup-git/tasks/main.yml
@@ -40,17 +40,8 @@
     - rpc
     - git
   command: >
-    git checkout {{branch}}
+    git checkout {{os_ansible_branch}}
     chdir={{rpc_repo_dir}}
-
-- name: Checkout target tag
-  tags:
-    - rpc
-    - git
-  command: >
-    git checkout {{latest_tag}}
-    chdir={{rpc_repo_dir}}
-  when: LATEST_TAG is defined
 
 - name: Get change from gerrit
   tags:

--- a/playbooks/vars/branch-vars-icehouse.yml
+++ b/playbooks/vars/branch-vars-icehouse.yml
@@ -1,3 +1,0 @@
-config_prefix: rpc
-branch: icehouse
-latest_tag: 9.0.6

--- a/playbooks/vars/branch-vars-juno.yml
+++ b/playbooks/vars/branch-vars-juno.yml
@@ -1,3 +1,0 @@
-config_prefix: rpc
-branch: juno
-latest_tag: 10.1.2

--- a/playbooks/vars/branch-vars-master.yml
+++ b/playbooks/vars/branch-vars-master.yml
@@ -1,3 +1,0 @@
-config_prefix: openstack
-branch: master
-latest_tag: master

--- a/playbooks/vars/commit-multinode.yml
+++ b/playbooks/vars/commit-multinode.yml
@@ -1,3 +1,4 @@
+config_prefix: openstack
 rpc_repo_dir: rpc_repo
 repo_url: http://rpc-repo.rackspace.com
 rpc_user_config:

--- a/playbooks/vars/icehouse-nightly.yml
+++ b/playbooks/vars/icehouse-nightly.yml
@@ -1,3 +1,4 @@
+config_prefix: rpc
 rpc_repo_dir: rpc_repo
 repo_url: http://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api

--- a/playbooks/vars/juno-nightly.yml
+++ b/playbooks/vars/juno-nightly.yml
@@ -1,3 +1,4 @@
+config_prefix: rpc
 rpc_repo_dir: rpc_repo
 repo_url: http://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api

--- a/scripts/commit-multinode.sh
+++ b/scripts/commit-multinode.sh
@@ -12,9 +12,9 @@ ansible-playbook \
   -e@vars/pip.yml\
   -e@vars/kernel.yml\
   -e@vars/commit-multinode.yml\
-  -e@vars/branch-vars-${TARGET_BRANCH}.yml\
   -e cluster_number=${CLUSTER_NUMBER}\
   -e GERRIT_REFSPEC=${GERRIT_REFSPEC}\
+  -e os_ansible_branch=${OS_ANSIBLE_BRANCH}\
   --tags $TAGS\
   $ANSIBLE_OPTIONS\
   commit-multinode.yml


### PR DESCRIPTION
Theres no need to have vars files for each branch when jenkins-rpc
itself now has a branch to match each os-ansible-deployment branch.

This patch removes branch vars, and expects the branch/tag to build to
be passed to the playbooks via -e as os_ansible_branch. This can be a
branch, tag or SHA (commitish).

This will require jenkins jobs to be modified to pass the
OS_ANSIBLE_BRANCH parameter to docker, which will pass it to ansible as
os_ansible_branch.