### PR TITLE
Revert "log results of os-ansible-script executions"

### DIFF
--- a/playbooks/roles/run-script-from-os-ansible-deployment/tasks/main.yml
+++ b/playbooks/roles/run-script-from-os-ansible-deployment/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "{{script_name}}"
   environment: script_env
-  shell: "scripts/{{script_name}}.sh |& tee /var/log/{{script_name}}.log"
+  shell: "scripts/{{script_name}}.sh"
   args:
     chdir: "{{rpc_repo_dir}}"
 


### PR DESCRIPTION
Reverts rcbops/jenkins-rpc#189

turns out that |& is a bashism and ansible is using another shell :(