### PR TITLE
Add script for rekicking clusters

### DIFF
--- a/playbooks/clean.yml
+++ b/playbooks/clean.yml
@@ -1,0 +1,13 @@
+---
+- name: Rekick cluster nodes
+  gather_facts: False
+  hosts: all
+  tasks:
+    - name: Rekick and wait for nodes to become available
+      delegate_to: localhost
+      rekick:
+        host_ip: "{{ ansible_ssh_host }}"
+        host_name: "{{ inventory_hostname }}"
+        kick_wait: 2400
+        kick_tries: 2
+        djeep_url: "http://10.127.52.2:8000/api"


### PR DESCRIPTION
Usage example:
ansible-playbook -i inventory/commit-cluster-3 clean.yml

(cherry picked from commit 201889d474479c3471ea2946f2fe45680df8ad89)