### PR TITLE
Create interface config for commit cluster em1

### DIFF
--- a/playbooks/vars/commit-multinode.yml
+++ b/playbooks/vars/commit-multinode.yml
@@ -145,6 +145,11 @@ networking:
       directives:
         - "bridge_ports em1.2{{cluster_number}}03"
         - "address 172.29.248.{{member_number}}/22"
+    - name: "em1"
+      type: "static"
+      directives:
+        - "address {{ansible_em1['ipv4']['address']}}"
+        - "netmask 255.255.255.0"
 
 # /dev/sda (gpt)
 # 1 - boot


### PR DESCRIPTION
The default config for em1 is overwritten when the network role runs,
and its config is not replaced. This means that em1 will not have an ip
if any boxes are rebooted.

This is not normally a problem as they are rekicked most times, but can
be a pain when troubleshooting.