### PR TITLE
Move multinode job logic into commit-multinode.sh

### DIFF
--- a/dockerfiles/jenkins-slave/Dockerfile
+++ b/dockerfiles/jenkins-slave/Dockerfile
@@ -21,7 +21,21 @@ RUN apt-get update
 
 # Upgrade and install things
 RUN apt-get upgrade -y
-RUN apt-get install -y jenkins git ssh-client lxc-docker unzip
+RUN apt-get install -y jenkins git ssh-client lxc-docker unzip python build-essential python-dev libssl-dev libffi-dev
+
+# install pip
+RUN curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
+RUN python get-pip.py
+
+# Install Requests
+RUN pip install requests pyyaml virtualenv ansible==1.8.4 jinja2
+
+# Add ssh keys
+ADD id_rsa /root/.ssh/id_rsa
+ADD id_rsa.pub /root/.ssh/id_rsa.pub
+
+# Add ssh config
+ADD ssh_config /root/.ssh/config
 
 # Use volume for Jenkins home
 ENV JENKINS_HOME /opt/jenkins

--- a/playbooks/clean.yml
+++ b/playbooks/clean.yml
@@ -2,12 +2,5 @@
 - name: Rekick cluster nodes
   gather_facts: False
   hosts: all
-  tasks:
-    - name: Rekick and wait for nodes to become available
-      delegate_to: localhost
-      rekick:
-        host_ip: "{{ ansible_ssh_host }}"
-        host_name: "{{ inventory_hostname }}"
-        kick_wait: 2400
-        kick_tries: 2
-        djeep_url: "http://10.127.52.2:8000/api"
+  roles:
+    - djeep-rekick

--- a/playbooks/commit-multinode.yml
+++ b/playbooks/commit-multinode.yml
@@ -21,7 +21,8 @@
 - hosts: all
   user: root
   roles:
-    - networking
+    - role: networking
+      bring_up_interfaces: yes
   tags: prepare
 
 - hosts: all
@@ -69,3 +70,12 @@
   roles:
     - role: run-script-from-os-ansible-deployment
       script_name: run-tempest
+      script_env:
+        TEMPEST_SCRIPT_PARAMETERS: commit_aio
+
+## --------- [ Clean up nodes] ---------------
+- hosts: all
+  gather_facts: false
+  tags: clean
+  roles:
+    - djeep-rekick

--- a/playbooks/roles/djeep-rekick/tasks/main.yml
+++ b/playbooks/roles/djeep-rekick/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Rekick and wait for nodes to become available
+  delegate_to: localhost
+  rekick:
+    host_ip: "{{ ansible_ssh_host }}"
+    host_name: "{{ inventory_hostname }}"
+    kick_wait: 2400
+    kick_tries: 2
+    djeep_url: "http://10.127.52.2:8000/api"
+
+- name: Wait for ssh to come back up
+  wait_for:
+    port: 22
+    timeout: 300
+
+- name: Ansible ping node post reboot
+  ping:

--- a/playbooks/roles/pip/tasks/main.yml
+++ b/playbooks/roles/pip/tasks/main.yml
@@ -4,14 +4,10 @@
     state: "directory"
     path: "/opt"
 
-- name: Get Modern PIP
-  get_url:
-    url: "{{ get_pip_url }}"
-    dest: "/opt/get-pip.py"
-    validate_certs: "no"
-  register: get_pip
-  until: get_pip|success
-  retries: 3
+- name: Get Modern Pip
+  shell: "for try in {1..10} :; do curl {{get_pip_url}} > /opt/get-pip.py; file /opt/get-pip.py | grep -q Python && break; sleep 30; done"
+  args:
+    executable: /bin/bash
 
 - name: Install pip
   shell: "python /opt/get-pip.py"

--- a/playbooks/roles/run-script-from-os-ansible-deployment/tasks/main.yml
+++ b/playbooks/roles/run-script-from-os-ansible-deployment/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "{{script_name}}"
   environment: script_env
-  shell: "scripts/{{script_name}}.sh |& tee -a /var/log/{{script_name}}.log"
+  shell: "set -o pipefail; scripts/{{script_name}}.sh |& tee -a /var/log/{{script_name}}.log"
   args:
     chdir: "{{rpc_repo_dir}}"
     executable: /bin/bash

--- a/scripts/commit-multinode.sh
+++ b/scripts/commit-multinode.sh
@@ -1,22 +1,161 @@
 #!/usr/bin/env bash
 
-CLUSTER_NUMBER=${CLUSTER_NUMBER:-1}
+### -------------- [ Variables ] --------------------
 TAGS=${TAGS:-prepare,run,test}
 OS_ANSIBLE_BRANCH=${OS_ANSIBLE_BRANCH:-master}
 GERRIT_REFSPEC=${GERRIT_REFSPEC:-refs/changes/87/139087/14}
 ANSIBLE_OPTIONS=${ANSIBLE_OPTIONS:--v}
+TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-scenario}
+### -------------- [ Functions ] --------------------
 
-ansible-playbook \
-  -i inventory/commit-cluster-$CLUSTER_NUMBER\
-  -e@vars/packages.yml\
-  -e@vars/pip.yml\
-  -e@vars/kernel.yml\
-  -e@vars/commit-multinode.yml\
-  -e cluster_number=${CLUSTER_NUMBER}\
-  -e GERRIT_REFSPEC=${GERRIT_REFSPEC}\
-  -e os_ansible_branch=${OS_ANSIBLE_BRANCH}\
-  --tags $TAGS\
-  $ANSIBLE_OPTIONS\
-  commit-multinode.yml
+env
 
+cluster_tool(){
+python - $@ <<EOP
+import requests
+import argparse
+import sys
+import os
 
+def cluster_for_claim(clusters, claim):
+        for cluster in clusters.json():
+            if cluster.get('claim') == claim:
+                print(cluster['short_name'])
+                return 0
+        return 1
+
+def check_release(clusters, name):
+        for cluster in clusters.json():
+                if cluster['short_name'] == name and cluster['claim'] == "":
+                        return 0
+        return 1
+
+def main():
+        parser=argparse.ArgumentParser()
+        parser.add_argument('command', choices=['cluster_for_claim','check_release'])
+        parser.add_argument('arg')
+
+        args = parser.parse_args()
+
+        base_url = "${DJEEP_URL}/api"
+
+        clusters = requests.get('%(base_url)s/clusters' % {'base_url': base_url} )
+
+        router = {'cluster_for_claim': cluster_for_claim,
+                  'check_release': check_release}
+
+        return router[args.command](clusters, args.arg)
+
+if __name__ == "__main__":
+        sys.exit(main())
+EOP
+}
+
+run_playbook_tag(){
+  echo "Running tag ${1} from jenkins-rpc/commit-multinode.yml"
+  ansible-playbook \
+    -i inventory/commit-cluster-$CLUSTER_NUMBER\
+    -e@vars/packages.yml\
+    -e@vars/pip.yml\
+    -e@vars/kernel.yml\
+    -e@vars/commit-multinode.yml\
+    -e cluster_number=${CLUSTER_NUMBER}\
+    -e GERRIT_REFSPEC=${GERRIT_REFSPEC}\
+    -e os_ansible_branch=${OS_ANSIBLE_BRANCH}\
+    --tags $1\
+    $ANSIBLE_OPTIONS\
+    commit-multinode.yml
+}
+
+run_script(){
+  #Find the first node ip from the inventory
+  [[ -z $infra_1_ip ]] && infra_1_ip=$(grep -o -m 1 '10.127.[0-9]\+.[0-9]\+' \
+                          < inventory/commit-cluster-$CLUSTER_NUMBER)
+  : >> /tmp/env
+  scp script_env $infra_1_ip:/tmp/env
+  echo "Running script ${1} from os-ansible-deployment/scripts."
+  ssh root@$infra_1_ip ". /tmp/env; cd ~/rpc_repo; bash scripts/${1}.sh"
+}
+
+prepare(){
+  run_playbook_tag prepare
+}
+
+run(){
+  echo "export DEPLOY_TEMPEST=yes" > script_env
+  run_script run-playbooks
+}
+
+test(){
+  echo "export TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS}" > script_env
+  run_script run-tempest
+}
+
+clean(){
+  run_playbook_tag clean
+}
+
+_claim(){
+  if [[ ! -z "$CLUSTER_NAME" ]]
+  then
+    echo "Claiming name: $CLUSTER_NAME with claim: $CLUSTER_CLAIM"
+    curl -X POST $DJEEP_URL/api/cluster/claim/$CLUSTER_CLAIM/$CLUSTER_NAME 2>/dev/null
+  else
+    echo "Claiming cluster with prefix $CLUSTER_PREFIX with claim: $CLUSTER_CLAIM"
+    curl -X POST $DJEEP_URL/api/cluster/claim/$CLUSTER_CLAIM/prefix/$CLUSTER_PREFIX 2>/dev/null
+  fi
+}
+
+claim(){
+  until _claim | tee cluster | grep claimed
+  do
+    sleep 5
+  done
+  export CLUSTER_NAME=$(awk '/claimed/{print $2}' < cluster)
+  export CLUSTER_NUMBER=${CLUSTER_NAME#dev_sat6_jenkins_}
+
+  # Check cluster status to ensure the claim is correct.
+  [[ "$CLUSTER_NAME" == "$(cluster_tool cluster_for_claim $CLUSTER_CLAIM)" ]]
+}
+
+release(){
+  echo "Releasing claim $CLUSTER_CLAIM from $CLUSTER_NAME"
+  curl -X DELETE $DJEEP_URL/api/cluster/claim/$CLUSTER_CLAIM/$CLUSTER_NAME 2>/dev/null
+
+  # Check that the claim has been released correctly
+  cluster_tool check_release $CLUSTER_NAME
+}
+
+# A propterties file (Java key=value format) is produced to be read by the
+# parent jenkins job. This is then used to inject CLUSTER_{NAME,CLAIM} into
+# the env for the cleanup job, so the correct cluster is cleaned and released
+write_properties(){
+  {
+    for var in $@
+    do
+      echo "${var}=${!var}"
+    done
+  } > properties
+}
+
+### -------------- [ Main ] --------------------
+
+export CLUSTER_NUMBER=${CLUSTER_NAME#dev_sat6_jenkins_}
+
+# Write properties is called early even though claim has not run yet, as
+# CLUSTER_NAME may have been passed in. Write properties is also called after
+# each tag incase claim has run. Its important that write_properties runs as
+# early as possible as cleanup will fail if the necessary info has not been written.
+write_properties CLUSTER_NAME CLUSTER_CLAIM
+
+# run the tags that are required until something breaks
+rc=0
+for tag in ${TAGS}
+do
+  $tag
+  rc=$(( $rc + $? ))
+  [[ $rc -ne 0 ]] && break
+  write_properties CLUSTER_NAME CLUSTER_CLAIM
+done
+
+exit $rc


### PR DESCRIPTION
This patch simplifies the commit multinode gating strategy by moving
some of the logic that was previously in jenkins jobs into the
commit-multinode.sh script.

It also removes a few layers:
 * no longer spawns a docker instance for each job, all jobs run within
   the jenkins-slave container
 * osad playbooks are no longer called from a role within jenkin-rpc
   playbooks, they are called directly over ssh.