### PR TITLE
volume group (cinder and swift) management fixes

### DIFF
--- a/playbooks/inventory/nightly-juno
+++ b/playbooks/inventory/nightly-juno
@@ -6,9 +6,9 @@ node118 ansible_ssh_host=10.127.101.118 ansible_ssh_user=root member_number=118
 node92 ansible_ssh_host=10.127.101.92 ansible_ssh_user=root member_number=92
 node93 ansible_ssh_host=10.127.101.93 ansible_ssh_user=root member_number=93
 node91 ansible_ssh_host=10.127.101.91 ansible_ssh_user=root member_number=91
-node119 ansible_ssh_host=10.127.101.119 ansible_ssh_user=root member_number=119 zone=1
-node107 ansible_ssh_host=10.127.101.107 ansible_ssh_user=root member_number=107 zone=2
-node120 ansible_ssh_host=10.127.101.120 ansible_ssh_user=root member_number=120 zone=3
+node119 ansible_ssh_host=10.127.101.119 ansible_ssh_user=root member_number=119
+node107 ansible_ssh_host=10.127.101.107 ansible_ssh_user=root member_number=107
+node120 ansible_ssh_host=10.127.101.120 ansible_ssh_user=root member_number=120
 
 [haproxy]
 node89
@@ -34,6 +34,6 @@ node118
 node91
 
 [swift]
-node119
-node107
-node120
+node119 zone=1
+node107 zone=2
+node120 zone=3

--- a/playbooks/inventory/nightly-master
+++ b/playbooks/inventory/nightly-master
@@ -2,9 +2,9 @@
 node108 ansible_ssh_host=10.127.101.108 ansible_ssh_user=root member_number=108
 node101 ansible_ssh_host=10.127.101.101 ansible_ssh_user=root member_number=101
 node98 ansible_ssh_host=10.127.101.98 ansible_ssh_user=root member_number=98
-node121 ansible_ssh_host=10.127.101.121 ansible_ssh_user=root member_number=121 zone=1
-node113 ansible_ssh_host=10.127.101.113 ansible_ssh_user=root member_number=113 zone=2
-node115 ansible_ssh_host=10.127.101.115 ansible_ssh_user=root member_number=115 zone=3
+node121 ansible_ssh_host=10.127.101.121 ansible_ssh_user=root member_number=121
+node113 ansible_ssh_host=10.127.101.113 ansible_ssh_user=root member_number=113
+node115 ansible_ssh_host=10.127.101.115 ansible_ssh_user=root member_number=115
 node84 ansible_ssh_host=10.127.101.84 ansible_ssh_user=root member_number=84
 node114 ansible_ssh_host=10.127.101.114 ansible_ssh_user=root member_number=114
 
@@ -33,6 +33,6 @@ node84
 node114
 
 [swift]
-node121
-node113
-node115
+node121 zone=1
+node113 zone=2
+node115 zone=3

--- a/playbooks/nightly-multinode.yml
+++ b/playbooks/nightly-multinode.yml
@@ -23,6 +23,8 @@
   tags: prepare
   roles:
     - networking
+    - volumes
+    - configure-rpc-swift-lvs
 
 - hosts: infrastructure[0]
   user: root

--- a/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
@@ -148,14 +148,14 @@ storage_hosts:
 {% if cinder_storage.backends.lvm is defined %}
         lvm:
           volume_group: {{ cinder_storage.backends.lvm.volume_group }}
-          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
-          volume_backend_name: LVM_iSCSI
+          volume_driver: {{ cinder_storage.backends.lvm.volume_driver }}
+          volume_backend_name: {{ cinder_storage.backends.lvm.volume_backend_name }}
 {% endif %}
 {% if cinder_storage.backends.lvm_ssd is defined %}
         lvm_ssd:
-          volume_group: {{ cinder_storage.backends.lvm.volume_group }}
-          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
-          volume_backend_name: LVM_SSD_iSCSI
+          volume_group: {{ cinder_storage.backends.lvm_ssd.volume_group }}
+          volume_driver: {{ cinder_storage.backends.lvm_ssd.volume_driver }}
+          volume_backend_name: {{ cinder_storage.backends.lvm_ssd.volume_backend_name }}
 {% endif %}
 {% if cinder_storage.backends.netapp is defined %}
         netapp:
@@ -165,8 +165,8 @@ storage_hosts:
           netapp_server_port: 80
           netapp_login: {{ cinder_storage.backends.netapp.username }}
           netapp_password: {{ cinder_storage.backends.netapp.password }}
-          volume_driver: cinder.volume.drivers.netapp.common.NetAppDriver
-          volume_backend_name: NETAPP_iSCSI
+          volume_driver: {{ cinder_storage.backends.lvm_ssd.volume_driver }}
+          volume_backend_name: {{ cinder_storage.backends.lvm_ssd.volume_backend_name }}
 {% endif %}
 {% endfor %}
 

--- a/playbooks/roles/configure-rpc-swift-lvs/tasks/main.yml
+++ b/playbooks/roles/configure-rpc-swift-lvs/tasks/main.yml
@@ -8,46 +8,26 @@
 
 - name: Create LVs for Swift
   lvol:
-    vg: lxc 
-    lv: "{{ item }}"
+    vg: "{{ swift_config.vg }}"
+    lv: "{{ item.name }}"
     size: 10G
-  with_items:
-    - swift1
-    - swift2
-    - swift3
-    - swift4
-    - swift5
+  with_items: swift_config.drives
 
 - name: Create swift mount dirs
   file:
     state: directory
-    path: "/mnt/{{ item }}"
-  with_items:
-    - swift1
-    - swift2
-    - swift3
-    - swift4
-    - swift5
+    path: "{{ swift_config.mount_point }}/{{ item.name }}"
+  with_items: swift_config.drives
 
 - name: mkfs.xfs swift partitions
-  shell: "xfs_info /dev/lxc/{{ item }} || mkfs.xfs -f /dev/lxc/{{ item }}"
-  with_items:
-    - swift1
-    - swift2
-    - swift3
-    - swift4
-    - swift5
+  shell: "xfs_info /dev/{{ swift_config.vg }}/{{ item.name }} || mkfs.xfs -f /dev/{{ swift_config.vg }}/{{ item.name }}"
+  with_items: swift_config.drives
 
 - name: Mount swift partitions
   mount: 
     state: mounted
     fstype: xfs
-    src: "/dev/lxc/{{ item }}"
-    name: "/mnt/{{ item }}"
-  with_items:
-    - swift1
-    - swift2
-    - swift3
-    - swift4
-    - swift5
+    src: "/dev/{{ swift_config.vg }}/{{ item.name }}"
+    name: "{{ swift_config.mount_point }}/{{ item.name }}"
+  with_items: swift_config.drives
 

--- a/playbooks/roles/volumes/tasks/main.yml
+++ b/playbooks/roles/volumes/tasks/main.yml
@@ -1,2 +1,3 @@
-- name: add volume group
-  lvg:  vg={{ volume_group }} state=present pvs={{ physical_drive }} pesize=8
+- name: add volume groups
+  lvg:  vg={{ item.name }} pvs={{ item.device }} pesize=8 state=present
+  with_items: vgs 

--- a/playbooks/vars/commit-multinode.yml
+++ b/playbooks/vars/commit-multinode.yml
@@ -73,6 +73,7 @@ rpc_user_config:
             - swift_proxy
 
 swift_config:
+  vg: lxc
   part_power: 8
   weight: 100
   min_part_hours: 1

--- a/playbooks/vars/nightly-juno.yml
+++ b/playbooks/vars/nightly-juno.yml
@@ -57,6 +57,7 @@ rpc_user_config:
             - nova_compute
             - swift_proxy
 swift_config:
+  vg: swift-volumes
   part_power: 8
   weight: 100
   min_part_hours: 1
@@ -64,10 +65,14 @@ swift_config:
   storage_network: 'br-storage' 
   replication_network: 'br-repl'
   drives:
-    - name: sdb
+    - name: swift1
+    - name: swift2
+    - name: swift3
+    - name: swift4
+    - name: swift5
   mount_point: /mnt
-  account: private_cloud_qe
-  container: sat6-lab02
+  account: "service:glance"
+  container: glance
   storage_policies:
     - name: gold
       index: 0
@@ -78,12 +83,10 @@ swift_config:
       depreciated: True
 cinder_storage:
   backends:
-    netapp:
-      username: test
-      hostname: test
-      password: test
     lvm:
-      volume_group: vg_storage
+      volume_group: cinder-volumes
+      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_backend_name: LVM_iSCSI
 networking:
     - name: lo
       type: loopback
@@ -205,3 +208,8 @@ networking:
         - "bridge_fd 0"
         - "bridge-ports bond2.2025"
         - "address 172.30.248.{{member_number}}/22"
+vgs:
+    - name: cinder-volumes
+      device: /dev/sdb1
+    - name: swift-volumes
+      device: /dev/sdb2

--- a/playbooks/vars/nightly-kilo.yml
+++ b/playbooks/vars/nightly-kilo.yml
@@ -56,6 +56,7 @@ rpc_user_config:
             - cinder_volume
             - nova_compute
 swift_config:
+  vg: swift-volumes
   part_power: 8
   weight: 100
   min_part_hours: 1
@@ -63,7 +64,11 @@ swift_config:
   storage_network: 'br-storage' 
   replication_network: 'br-repl'
   drives:
-    - name: sdb
+    - name: swift1
+    - name: swift2
+    - name: swift3
+    - name: swift4
+    - name: swift5
   mount_point: /mnt
   account: private_cloud_qe
   container: sat6-lab01
@@ -204,3 +209,8 @@ networking:
         - "bridge_fd 0"
         - "bridge-ports bond2.2005"
         - "address 172.30.244.{{member_number}}/22"
+vgs:
+    - name: cinder-volumes
+      device: /dev/sdb1
+    - name: swift-volumes
+      device: /dev/sdb2

--- a/playbooks/vars/nightly-master.yml
+++ b/playbooks/vars/nightly-master.yml
@@ -61,7 +61,9 @@ rpc_user_config:
             - cinder_api
             - cinder_volume
             - nova_compute
+            - swift_proxy
 swift_config:
+  vg: swift-volumes
   part_power: 8
   weight: 100
   min_part_hours: 1
@@ -69,10 +71,14 @@ swift_config:
   storage_network: 'br-storage' 
   replication_network: 'br-repl'
   drives:
-    - name: sdb
+    - name: swift1
+    - name: swift2
+    - name: swift3
+    - name: swift4
+    - name: swift5
   mount_point: /mnt
-  account: private_cloud_qe
-  container: sat6-lab01
+  account: "service:glance"
+  container: glance
   storage_policies:
     - name: gold
       index: 0
@@ -83,12 +89,10 @@ swift_config:
       depreciated: True
 cinder_storage:
   backends:
-    netapp:
-      username: test
-      hostname: test
-      password: test
     lvm:
-      volume_group: vg_storage
+      volume_group: cinder-volumes
+      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_backend_name: LVM_iSCSI
 networking:
     - name: lo
       type: loopback
@@ -210,3 +214,8 @@ networking:
         - "bridge_fd 0"
         - "bridge-ports bond2.2005"
         - "address 172.30.244.{{member_number}}/22"
+vgs:
+    - name: cinder-volumes
+      device: /dev/sdb1
+    - name: swift-volumes
+      device: /dev/sdb2


### PR DESCRIPTION
updated how volume groups and logical volumes are created and used for both

swift and cinder volumes. This should allow for more granualr contrl of hosts
and the disks that each lab uses going forward.

fixes #243 