### PR TITLE
Remove http warning when using pip

### DIFF
--- a/playbooks/vars/commit-multinode.yml
+++ b/playbooks/vars/commit-multinode.yml
@@ -1,7 +1,7 @@
 # dir / repo info
 config_prefix: openstack
 rpc_repo_dir: rpc_repo
-repo_url: http://rpc-repo.rackspace.com
+repo_url: https://rpc-repo.rackspace.com
 
 # rpc_user_config info
 rpc_user_config:

--- a/playbooks/vars/eng-iad3-lab02.yml
+++ b/playbooks/vars/eng-iad3-lab02.yml
@@ -1,7 +1,7 @@
 # dir and repo info
 config_prefix: openstack
 rpc_repo_dir: rpc_repo
-repo_url: http://rpc-repo.rackspace.com
+repo_url: https://rpc-repo.rackspace.com
 
 # all rpc user configuration
 rpc_user_config:

--- a/playbooks/vars/nightly-icehouse.yml
+++ b/playbooks/vars/nightly-icehouse.yml
@@ -1,6 +1,6 @@
 config_prefix: rpc
 rpc_repo_dir: rpc_repo
-repo_url: http://rpc-repo.rackspace.com
+repo_url: https://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 rpc_user_config:
     container_cidr: 172.29.236.0/22

--- a/playbooks/vars/nightly-juno.yml
+++ b/playbooks/vars/nightly-juno.yml
@@ -1,6 +1,6 @@
 config_prefix: rpc
 rpc_repo_dir: rpc_repo
-repo_url: http://rpc-repo.rackspace.com
+repo_url: https://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 
 rpc_user_config:

--- a/playbooks/vars/nightly-kilo.yml
+++ b/playbooks/vars/nightly-kilo.yml
@@ -1,7 +1,7 @@
 # repo configuration info
 config_prefix: openstack
 rpc_repo_dir: rpc_repo
-repo_url: http://rpc-repo.rackspace.com
+repo_url: https://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 
 # private cloud user config

--- a/playbooks/vars/nightly-master.yml
+++ b/playbooks/vars/nightly-master.yml
@@ -1,7 +1,7 @@
 # repo / dir info
 config_prefix: openstack
 rpc_repo_dir: rpc_repo
-repo_url: http://rpc-repo.rackspace.com
+repo_url: https://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 
 # rpc user config info

--- a/playbooks/vars/qe-iad3-lab01.yml
+++ b/playbooks/vars/qe-iad3-lab01.yml
@@ -1,7 +1,7 @@
 # repo configuration info
 config_prefix: openstack
 rpc_repo_dir: rpc_repo
-repo_url: http://rpc-repo.rackspace.com
+repo_url: https://rpc-repo.rackspace.com
 
 rpc_user_config:
     container_cidr: 172.29.236.0/22


### PR DESCRIPTION
When not using https the following warning is generated in the logs:

'http://rpc-repo.rackspace.com/python_packages/juno/ uses an insecure
transport scheme (http). Consider using https if rpc-repo.rackspace.com
has it available'

This commit updates the repo_url vars to use https.

(cherry picked from commit d2d18e07b94f23e690ddae6604a62c41dac1f2d3)