### PR TITLE
Adjust tags to run all required plays in one.

### DIFF
--- a/playbooks/nightly-multinode.yml
+++ b/playbooks/nightly-multinode.yml
@@ -38,15 +38,26 @@
     - setup-git
 
 - hosts: infrastructure[0]
+  tags: prepare
   user: root
-  tags: configure
+  roles:
+    - role: run-script-from-os-ansible-deployment
+      script_name: bootstrap-ansible
+
+- hosts: infrastructure[0]
+  user: root
+  tags:
+    - configure
+    - prepare
   roles:
     - configure-rpc-compute
     - configure-rpc-swift
 
 - hosts: all
   user: root
-  tags: reboot
+  tags:
+    - reboot
+    - prepare
   roles:
     - reboot
 
@@ -72,11 +83,15 @@
   roles:
     - role: setup-git
 
+
+
 ## --------- [ Rekick Cluster ] ------------------
 - hosts: cinder
   gather_facts: no
   user: root
-  tags: cleanup
+  tags:
+    - cleanup
+    - rekick
   roles:
     - cleanup-cinder-volumes
 

--- a/scripts/nightly-multinode.sh
+++ b/scripts/nightly-multinode.sh
@@ -53,9 +53,6 @@ run_upgrade(){
 
 prepare(){
   run_playbook_tag prepare
-  run_script bootstrap-ansible
-  run_playbook_tag configure
-  run_playbook_tag reboot
 
   # sleep for 2 minutes to wait for ssh
   echo "Sleeping for 3 minutes to allow ssh to come up."
@@ -81,7 +78,6 @@ upgrade(){
 }
 
 rekick(){
-  run_playbook_tag cleanup
   run_playbook_tag rekick
 
   # sleep for 3 minutes to wait for ssh


### PR DESCRIPTION
This change ensures that a failure on a specific play will cause the
step to fail instead of succeeding because, for example, the reboot play
(which is last) succeeds despite the other plays all failing.

(cherry picked from commit 64e5485f1dae82860e2e08a11c178810633ce435)