### PR TITLE
Adjust tags to run all required plays in one.

### DIFF
--- a/playbooks/nightly-multinode.yml
+++ b/playbooks/nightly-multinode.yml
@@ -32,14 +32,25 @@
     - setup-git
 
 - hosts: infrastructure[0]
+  tags: prepare
   user: root
-  tags: configure
+  roles:
+    - role: run-script-from-os-ansible-deployment
+      script_name: bootstrap-ansible
+
+- hosts: infrastructure[0]
+  user: root
+  tags:
+    - configure
+    - prepare
   roles:
     - configure-rpc-compute
 
 - hosts: all
   user: root
-  tags: reboot
+  tags:
+    - reboot
+    - prepare
   roles:
     - reboot
 
@@ -63,7 +74,9 @@
 - hosts: cinder
   gather_facts: no
   user: root
-  tags: cleanup
+  tags:
+    - cleanup
+    - rekick
   roles:
     - cleanup-cinder
 

--- a/scripts/nightly-multinode.sh
+++ b/scripts/nightly-multinode.sh
@@ -40,9 +40,6 @@ run_script(){
 
 prepare(){
   run_playbook_tag prepare
-  run_script bootstrap-ansible
-  run_playbook_tag configure
-  run_playbook_tag reboot
 
   # sleep for 2 minutes to wait for ssh
   echo "Sleeping for 3 minutes to allow ssh to come up."
@@ -60,7 +57,6 @@ test(){
 }
 
 rekick(){
-  run_playbook_tag cleanup
   run_playbook_tag rekick
 
   # sleep for 3 minutes to wait for ssh


### PR DESCRIPTION
This change ensures that a failure on a specific play will cause the
step to fail instead of succeeding because, for example, the reboot play
(which is last) succeeds despite the other plays all failing.

(cherry picked from commit 64e5485f1dae82860e2e08a11c178810633ce435)