### PR TITLE
added razor module ability to rekick via the razor api instead of a

### DIFF
--- a/playbooks/library/razor
+++ b/playbooks/library/razor
@@ -593,6 +593,49 @@ class ManageRazor(object):
                 msg=r.json()['error']
             )
 
+    def reboot_node(self, variables, required_vars):
+        """Issues a reboot node command
+
+        This will return 'None' if the node is not found.
+
+        :param variables: ``list``  List of all variables that are available
+                                    with the Razor command.
+        :param required_vars: ``list``  List of all required variables for the
+                                        Razor command.
+        """
+        # Build out request headers
+        headers = {'content-type': 'application/json'}
+
+        # Build out the request body and headers
+        body = self._get_vars(variables, required=required_vars)
+
+        # build out extension
+        extension = ('%s' %
+                     COMMAND_MAP['reboot-node']['extension'] %
+                     {'command': self.module.params['command']})
+
+        # build out request url
+        url = '%(url)s%(extension)s' % dict(url=self.url, extension=extension)
+
+        # issue api request
+        r = requests.post(url, data=json.dumps(body), headers=headers)
+
+        # add return value work here
+        if r.status_code == requests.codes.accepted:
+            self.module.exit_json(
+                cmd='%s with body %s' % (url, body),
+                stdout=r.json()['result'],
+                changed=True,
+                stderr=False,
+                rc=0
+            )
+        else:
+            self.failure(
+                error='Bad Request',
+                rc=2,
+                msg=r.json()['error']
+            )
+
     def reinstall_node(self, variables, required_vars):
         """Issues a reinstall node command
 

--- a/playbooks/roles/razor-rekick/tasks/main.yml
+++ b/playbooks/roles/razor-rekick/tasks/main.yml
@@ -6,10 +6,12 @@
     name: '{{ inventory_hostname }}'
 
 - name: reboot machine
-  command: shutdown -r now "Razor rekick issued"
+  razor:
+    url: '{{ razor_url }}'
+    command: 'reboot-node'
+    name: '{{ inventory_hostname }}'
   async: 0
   poll: 0
-  ignore_errors: true
 
 - name: waiting for server to come back
   local_action: 


### PR DESCRIPTION
shutdown issued directly via ssh to the host. This will require
setting the ipmi creds and ensuring that razor can issue ipmi commands
to all hosts. https://github.com/puppetlabs/razor-server/wiki/IPMI-support

(cherry picked from commit 325fec6b9a6aa1a9a444f5961d47454020e5b72c)