### PR TITLE
Disable tempest_compute_run_ssh

### DIFF
--- a/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
@@ -7,6 +7,9 @@ glance_swift_store_key: '{{ glance_service_password }}'
 glance_swift_store_region: RegionOne
 glance_swift_store_user: 'service:glance'
 tempest_public_subnet_cidr: '172.29.248.0/22'
+# See https://bugs.launchpad.net/openstack-ansible/+bug/1442823
+# TODO: revert this once these tests can run successfully w/ run_ssh: True
+tempest_compute_run_ssh: False
 ssl_protocol: "ALL -SSLv2 -SSLv3"
 ssl_cipher_suite: "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
 {% endraw %}


### PR DESCRIPTION
Currently, a number of tempest compute api tests are failing as
instances are not being brought up correctly with a floating IP
address.  This makes ssh'ing into the instances impossible and therefore
we need to set tempest's run_ssh option to False.

Once tempest is updated to properly create floating IP addresses for
all tests then we should be able to flip this variable back to True.