### PR TITLE
Add OSAD repo URL as an Ansible variable

### DIFF
--- a/playbooks/roles/setup-git/tasks/main.yml
+++ b/playbooks/roles/setup-git/tasks/main.yml
@@ -24,7 +24,7 @@
     - rpc
     - git
   git: >
-    repo=https://github.com/stackforge/os-ansible-deployment
+    repo={{os_ansible_url}}
     dest={{rpc_repo_dir}}
 
 - name: Fetch origin

--- a/scripts/commit-multinode.sh
+++ b/scripts/commit-multinode.sh
@@ -2,6 +2,7 @@
 
 ### -------------- [ Variables ] --------------------
 TAGS=${TAGS:-prepare,run,test}
+OS_ANSIBLE_URL={$OS_ANSIBLE_URL:-https://github.com/stackforge/os-ansible-deployment}
 OS_ANSIBLE_BRANCH=${OS_ANSIBLE_BRANCH:-master}
 GERRIT_REFSPEC=${GERRIT_REFSPEC:-refs/changes/87/139087/14}
 ANSIBLE_OPTIONS=${ANSIBLE_OPTIONS:--v}
@@ -61,6 +62,7 @@ run_jenkins_rpc_playbook_tag(){
     -e@vars/commit-multinode.yml\
     -e cluster_number=${CLUSTER_NUMBER}\
     -e GERRIT_REFSPEC=${GERRIT_REFSPEC}\
+    -e os_ansible_url=${OS_ANSIBLE_URL}\
     -e os_ansible_branch=${OS_ANSIBLE_BRANCH}\
     --tags $1\
     $ANSIBLE_OPTIONS\

--- a/scripts/nightly-multinode.sh
+++ b/scripts/nightly-multinode.sh
@@ -23,6 +23,7 @@ run_playbook_tag(){
   ansible-playbook \
     -i inventory/nightly-${LAB}\
     -e @vars/nightly-${LAB}.yml\
+    -e os_ansible_url=${OS_ANSIBLE_URL}\
     -e os_ansible_branch=${OS_ANSIBLE_BRANCH}\
     --tags $1\
     $ANSIBLE_OPTIONS\
@@ -48,7 +49,7 @@ run_upgrade(){
   echo "export ANSIBLE_FORCE_COLOR=$ANSIBLE_FORCE_COLOR" >> script_env
   scp script_env $infra_1_ip:/tmp/env
   echo "Running script ${1} from os-ansible-deployment/scripts."
-  ssh root@$infra_1_ip "source /tmp/env; cd ~/rpc_repo; echo $UPGRADE | bash scripts/${1}.sh" 
+  ssh root@$infra_1_ip "source /tmp/env; cd ~/rpc_repo; echo $UPGRADE | bash scripts/${1}.sh"
 }
 
 prepare(){

--- a/scripts/release-multinode.sh
+++ b/scripts/release-multinode.sh
@@ -23,6 +23,7 @@ run_playbook_tag(){
   ansible-playbook \
     -i inventory/${LAB}\
     -e @vars/${LAB}.yml\
+    -e os_ansible_url=${OS_ANSIBLE_URL}\
     -e os_ansible_branch=${OS_ANSIBLE_BRANCH}\
     --tags $1\
     $ANSIBLE_OPTIONS\


### PR DESCRIPTION
This addition let me test a local patch from Jenkins. I've made the change backwards compatible with the commit-multinode job, too.