### PR TITLE
Adjust pip install task for juno.

### DIFF
--- a/playbooks/roles/pip/tasks/main.yml
+++ b/playbooks/roles/pip/tasks/main.yml
@@ -10,7 +10,7 @@
     executable: /bin/bash
 
 - name: Install pip
-  shell: "python /opt/get-pip.py --no-index --find-links={{ repo_url }}/python_packages/{{ os_ansible_branch }}/"
+  shell: "python /opt/get-pip.py"
 
 - name: install all required pip packages
   pip: name={{ item }} state=latest


### PR DESCRIPTION
Set the pip install task for juno to match kilo and master.
Resolves failures on the juno nightly gate.