### PR TITLE
Cleanup compute node teardown

### DIFF
--- a/playbooks/roles/teardown-compute-node/tasks/nova.yml
+++ b/playbooks/roles/teardown-compute-node/tasks/nova.yml
@@ -3,17 +3,14 @@
   command: service nova-compute stop
   ignore_errors: yes
 
-- name: Get all running vms
-  shell: "virsh list | grep instance | awk '{print $2}'"
+- name: Gather VMs
+  virt: command=list_vms
   register: instances
 
-- name: Stop all running instances
-  virt: name={{ item }} command=shutdown
-  with_items: instances.stdout_lines
-
-- name: Destroy all instances
+- name: Destroy VMs
   virt: name={{ item }} command=destroy
-  with_items: instances.stdout_lines
+  with_items: instances.list_vms
+  ignore_errors: yes
 
 - name: Uninstall nova and python-neutronclient
   pip: name={{ item }} state=absent


### PR DESCRIPTION
Replace the shell command which lists VMs with the built-in equivalent. Using the resulting VM list, then destroy them. Any errors should be ignored because if the domain doesn't exist, then we're good to proceed.