### PR TITLE
Add hardcoded pip mirror repository

### DIFF
--- a/playbooks/roles/configure-rpc-compute/tasks/main.yml
+++ b/playbooks/roles/configure-rpc-compute/tasks/main.yml
@@ -1,28 +1,28 @@
 ---
 - name: Install pip requirements
-  pip: requirements=~/{{rpc_repo_dir}}/requirements.txt
+  pip: requirements=~/{{ rpc_repo_dir }}/requirements.txt
 
-- name: Copy rpc_deploy directory
-  command: cp -a ~/{{rpc_repo_dir}}/etc/{{config_prefix}}_deploy /etc/{{config_prefix}}_deploy
-           creates=/etc/{{config_prefix}}_deploy
+- name: Copy 'rpc_deploy' directory
+  command: cp --archive ~/{{ rpc_repo_dir }}/etc/{{ config_prefix }}_deploy /etc/{{ config_prefix }}_deploy
+           creates=/etc/{{ config_prefix }}_deploy
 
-- name: Set environment_md5 fact for template
-  stat: path=/etc/{{config_prefix}}_deploy/{{config_prefix}}_environment.yml
+- name: Gather environment MD5
+  stat: path=/etc/{{ config_prefix }}_deploy/{{ config_prefix }}_environment.yml
   register: environment_version
 
-- name: install rpc user config file
+- name: Install user configuration file
   template: src=rpc_user_config.j2
-            dest=/etc/{{config_prefix}}_deploy/{{config_prefix}}_user_config.yml
+            dest=/etc/{{ config_prefix }}_deploy/{{ config_prefix }}_user_config.yml
 
-- name: install user variables file
+- name: Install user variables file
   template: src=user_variables.j2
-            dest=/etc/{{config_prefix}}_deploy/user_variables.yml
+            dest=/etc/{{ config_prefix }}_deploy/user_variables.yml
 
 - name: Create passphrases file
-  file: path=/etc/{{config_prefix}}_deploy/user_secrets.yml
+  file: path=/etc/{{ config_prefix }}_deploy/user_secrets.yml
         state=touch
         owner=root
         mode=0644
 
 - name: Generate passphrases
-  command: ~/{{rpc_repo_dir}}/scripts/pw-token-gen.py --file /etc/{{config_prefix}}_deploy/user_secrets.yml
+  command: ~/{{ rpc_repo_dir }}/scripts/pw-token-gen.py --file /etc/{{ config_prefix }}_deploy/user_secrets.yml

--- a/playbooks/roles/configure-rpc-compute/templates/backends.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/backends.j2
@@ -1,4 +1,4 @@
-{% extends "rpc_user_config.j2" %}
+{% extends "{{ config_prefix }}_user_config.j2" %}
 {% block lvm %}
 container_vars:
   cinder_backends:

--- a/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/rpc_user_config.j2
@@ -41,10 +41,6 @@ used_ips:
 
 # overrides anything else any where.
 global_overrides:
-  {% if rpc_user_config.rpc_repo_url is defined %}
-  # Repo for pip wheels.
-  rpc_repo_url: "{{ rpc_user_config.rpc_repo_url }}"
-  {% endif %}
 
   # Internal Management vip address
   internal_lb_vip_address: {{ rpc_user_config.internal_lb_vip_address }}

--- a/playbooks/roles/configure-rpc-compute/templates/target.sh.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/target.sh.j2
@@ -12,7 +12,7 @@ arc(){
 
 rc=0
 
-pushd {{rpc_repo_dir}}/rpc_deployment
+pushd {{ rpc_repo_dir }}/rpc_deployment
 
 # fail fast on anything that exits with an error level > 0
 set -e

--- a/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
+++ b/playbooks/roles/configure-rpc-compute/templates/user_variables.j2
@@ -1,9 +1,12 @@
-{% raw %}glance_default_store: swift
+glance_default_store: swift
+{% if rpc_repo_url is defined %}
+openstack_repo_url: '{{ repo_url }}'
+{% endif %}
 glance_notification_driver: noop
-glance_swift_store_auth_address: '{{ keystone_service_internalurl }}'
+glance_swift_store_auth_address: {{ "'{{ keystone_service_internalurl }}'" }}
 glance_swift_store_container: glance_images
 glance_swift_store_endpoint_type: internalURL
-glance_swift_store_key: '{{ glance_service_password }}'
+glance_swift_store_key: {{ "'{{ glance_service_password }}'" }}
 glance_swift_store_region: RegionOne
 glance_swift_store_user: 'service:glance'
 tempest_public_subnet_cidr: '172.29.248.0/22'
@@ -12,4 +15,3 @@ tempest_public_subnet_cidr: '172.29.248.0/22'
 tempest_compute_run_ssh: False
 ssl_protocol: "ALL -SSLv2 -SSLv3"
 ssl_cipher_suite: "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
-{% endraw %}

--- a/playbooks/roles/configure-rpc-swift/tasks/main.yml
+++ b/playbooks/roles/configure-rpc-swift/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: create rpc deploy conf.d folder
+- name: Create 'rpc_deploy' conf.d folder
   file: path=/etc/{{ config_prefix }}_deploy/conf.d
         state=directory
         mode=0755
   when: swift_config is defined
 
-- name: create and configure the swift.yml file
+- name: Create and configure the swift.yml file
   template: src=swift.j2
             dest=/etc/{{ config_prefix }}_deploy/conf.d/swift.yml
             mode=0644

--- a/playbooks/roles/setup-git/tasks/main.yml
+++ b/playbooks/roles/setup-git/tasks/main.yml
@@ -17,15 +17,15 @@
     - rpc
     - git
   command:
-    rm -rf {{rpc_repo_dir}}
+    rm -rf {{ rpc_repo_dir }}
 
 - name: Clone stackforge repo
   tags:
     - rpc
     - git
   git: >
-    repo={{os_ansible_url}}
-    dest={{rpc_repo_dir}}
+    repo={{ os_ansible_url }}
+    dest={{ rpc_repo_dir }}
 
 - name: Fetch origin
   tags:
@@ -33,15 +33,15 @@
     - git
   command: >
     git fetch origin
-    chdir={{rpc_repo_dir}}
+    chdir={{ rpc_repo_dir }}
 
 - name: Checkout target branch
   tags:
     - rpc
     - git
   command: >
-    git checkout {{os_ansible_branch}}
-    chdir={{rpc_repo_dir}}
+    git checkout {{ os_ansible_branch }}
+    chdir={{ rpc_repo_dir }}
 
 - name: Get change from gerrit
   tags:
@@ -50,7 +50,7 @@
   shell:
     git fetch https://review.openstack.org/stackforge/os-ansible-deployment {{GERRIT_REFSPEC}}
   args:
-    chdir: "{{rpc_repo_dir}}"
+    chdir: "{{ rpc_repo_dir }}"
   when: GERRIT_REFSPEC is defined
 
 - name: Merge Review
@@ -59,5 +59,5 @@
     - git
   command: >
     git merge FETCH_HEAD
-    chdir={{rpc_repo_dir}}
+    chdir={{ rpc_repo_dir }}
   when: GERRIT_REFSPEC is defined

--- a/playbooks/vars/eng-iad3-lab02.yml
+++ b/playbooks/vars/eng-iad3-lab02.yml
@@ -1,9 +1,8 @@
-# dir and repo info
+# repo configuration info
 config_prefix: openstack
-rpc_repo_dir: rpc_repo
+rpc_repo_dir: os-ansible-deployment
 repo_url: https://rpc-repo.rackspace.com
 
-# all rpc user configuration
 rpc_user_config:
     container_cidr: 172.29.236.0/22
     tunnel_cidr:  172.29.240.0/22
@@ -69,7 +68,7 @@ swift_config:
   weight: 100
   min_part_hours: 1
   repl_number: 3
-  storage_network: 'br-storage' 
+  storage_network: 'br-storage'
   replication_network: 'br-storage'
   drives:
     - name: sdd

--- a/playbooks/vars/fcfs-iad3-lab03.yml
+++ b/playbooks/vars/fcfs-iad3-lab03.yml
@@ -1,9 +1,9 @@
-# dir and repo info
+# repo configuration info
 config_prefix: openstack
-openstack_repo_dir: os-ansible-deployment
+rpc_repo_dir: os-ansible-deployment
+repo_url: http://rpc-repo.rackspace.com
 
-# all OSAD user configuration
-openstack_user_config:
+rpc_user_config:
     container_cidr: 172.27.236.0/22
     tunnel_cidr:  172.27.240.0/22
     storage_cidr:  172.27.244.0/22
@@ -12,7 +12,6 @@ openstack_user_config:
         - "172.27.236.73,172.27.236.127"
         - "172.27.240.73,172.27.240.127"
         - "172.27.244.73,172.27.244.127"
-    openstack_repo_url: http://rpc-repo.rackspace.com
     internal_lb_vip_address: 172.27.236.10
     external_lb_vip_address: 72.4.117.65
     tunnel_bridge: br-vxlan

--- a/playbooks/vars/pip.yml
+++ b/playbooks/vars/pip.yml
@@ -1,2 +1,2 @@
 pip: []
-get_pip_url: "https://mirror.rackspace.com/rackspaceprivatecloud/downloads/get-pip.py"
+get_pip_url: "https://bootstrap.pypa.io/get-pip.py"

--- a/scripts/release-multinode.sh
+++ b/scripts/release-multinode.sh
@@ -3,9 +3,9 @@
 ### -------------- [ Variables ] --------------------
 LAB=${LAB:-master}
 TAGS=${TAGS:-cleanup prepare run upgrade test}
-OS_ANSIBLE_URL=${OS_ANSIBLE_URL:-git@github.com:stackforge/os-ansible-deployment.git}
+OS_ANSIBLE_URL=${OS_ANSIBLE_URL:-https://github.com/stackforge/os-ansible-deployment}
 OS_ANSIBLE_BRANCH=${OS_ANSIBLE_BRANCH:-master}
-JENKINS_RPC_URL=${JENKINS_RPC_URL:-git@github.com:rcbops/jenkins-rpc.git}
+JENKINS_RPC_URL=${JENKINS_RPC_URL:-https://github.com/rcbops/jenkins-rpc}
 JENKINS_RPC_BRANCH=${JENKINS_RPC_BRANCH:-master}
 TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-api}
 ANSIBLE_FORCE_COLOR=${ANSIBLE_FORCE_COLOR:-1}
@@ -44,7 +44,7 @@ run_script(){
 run_upgrade(){
   #Find the first node ip from the inventory
   [[ -z $infra_1_ip ]] && infra_1_ip=$(grep -o -m 1 '10.127.[0-9]\+.[0-9]\+' \
-                          < inventory/nightly-$LAB)
+                          < inventory/$LAB)
   : >> /tmp/env
   echo "export ANSIBLE_FORCE_COLOR=$ANSIBLE_FORCE_COLOR" >> script_env
   scp script_env $infra_1_ip:/tmp/env


### PR DESCRIPTION
Upstream, local pip repos are now used in lieu of a Rackspace mirror. This PR adds a repo mirror's URL as a temporary workaround.

Some syntax has also been changed to fit with Ansible's style guide. The pip installation URL is also updated to follow the upstream source.

The 'nightly' prefix has also been removed from the upgrade bash function. It was causing long-live environment files to not be found even when specified correctly within Jenkins.