### PR TITLE
Remove pip repository URL

### DIFF
--- a/playbooks/vars/eng-iad3-lab02.yml
+++ b/playbooks/vars/eng-iad3-lab02.yml
@@ -1,7 +1,7 @@
 # repo configuration info
 config_prefix: openstack
 rpc_repo_dir: os-ansible-deployment
-repo_url: https://rpc-repo.rackspace.com
+# repo_url: https://rpc-repo.rackspace.com
 
 rpc_user_config:
     container_cidr: 172.29.236.0/22

--- a/playbooks/vars/fcfs-iad3-lab03.yml
+++ b/playbooks/vars/fcfs-iad3-lab03.yml
@@ -1,7 +1,7 @@
 # repo configuration info
 config_prefix: openstack
 rpc_repo_dir: os-ansible-deployment
-repo_url: http://rpc-repo.rackspace.com
+# repo_url: http://rpc-repo.rackspace.com
 
 rpc_user_config:
     container_cidr: 172.27.236.0/22


### PR DESCRIPTION
This variable shouldn’t be necessary currently and for the future.

A local repository is now built within deployments, so a failure to contact one in the future should be categorized as an environment mis-configuration and not an OSAD one.