### PR TITLE
Dont accumulate return codes

### DIFF
--- a/scripts/commit-multinode.sh
+++ b/scripts/commit-multinode.sh
@@ -163,9 +163,7 @@ write_properties CLUSTER_NAME CLUSTER_CLAIM
 rc=0
 for tag in ${TAGS}
 do
-  $tag
-  rc=$(( $rc + $? ))
-  [[ $rc -ne 0 ]] && break
+  $tag || { rc=1; break; }
   write_properties CLUSTER_NAME CLUSTER_CLAIM
 done
 


### PR DESCRIPTION
Currently the final return code is the sum of previous return codes.
This can be problematic as if the return codes sum to 256, that will be
intepreted as success when it actually represents multiple failures.

This patch ensures the return code is 0 for success or 1 for failure
regardless of the number of failures.

(cherry picked from commit f9a2d00db90e4aa34d8fbbc94f31fa0a3a5ca694)