### PR TITLE
Add Finally Tags

### DIFF
--- a/scripts/commit-multinode.sh
+++ b/scripts/commit-multinode.sh
@@ -161,12 +161,18 @@ export CLUSTER_NUMBER=${CLUSTER_NAME#dev_sat6_jenkins_}
 # early as possible as cleanup will fail if the necessary info has not been written.
 write_properties CLUSTER_NAME CLUSTER_CLAIM
 
-# run the tags that are required until something breaks
+# run the tags that are required (from the $TAGS parameter) until something breaks
 rc=0
 for tag in ${TAGS}
 do
   $tag || { rc=1; break; }
   write_properties CLUSTER_NAME CLUSTER_CLAIM
+done
+
+# run tags from the list FINALLY_TAGS, these are intended to do cleanup.
+for tag in ${FINALLY_TAGS}
+do
+  $tag || break
 done
 
 exit $rc


### PR DESCRIPTION
Finally tags is a new parameter that specifies a list of tags that run
after the initial tags list ($TAGS) reagrdless of the exit status of the
first list.

This enables the job to break out of the $TAGS list after any failure
but still continue on to $FINALLY_TAGS and do any info collection /
cleanup tasks that are required.

(cherry picked from commit 8bd7d168f4f0dc4a1df8e2bc25c68e489ba8c67f)

Conflicts:
	scripts/commit-multinode.sh