### PR TITLE
Replace RPC repo removal with file-module equivalent

### DIFF
--- a/playbooks/roles/setup-git/tasks/main.yml
+++ b/playbooks/roles/setup-git/tasks/main.yml
@@ -25,8 +25,9 @@
   tags:
     - rpc
     - git
-  command:
-    rm -rf {{ rpc_repo_dir }}
+  file: >
+    path: {{ rpc_repo_dir }}
+    state: absent
 
 - name: Clone stackforge repo
   tags:


### PR DESCRIPTION
https://groups.google.com/d/msg/ansible-project/hN-lEidIv6E/kyqQL38eRAQJ

DeHaan recommends using the `shell` module for recursively deleting files within a directory.

The `file` module currently does not support wildcard arguments within a provided path. Alternatively, registering the output of a directory listing as input for a recursively deleting for-loop will not work within Ansible; the module works on a per-file basis so, in this scenario, the `state=absent` & `recurse=yes` options are mutually exclusive.

Closes Issue: https://github.com/rcbops/jenkins-rpc/issues/377