### PR TITLE
Use google DNS resolver

### DIFF
--- a/playbooks/vars/commit-multinode.yml
+++ b/playbooks/vars/commit-multinode.yml
@@ -160,6 +160,7 @@ networking:
       directives:
         - "address {{ansible_em1['ipv4']['address']}}"
         - "netmask 255.255.255.0"
+        - "dns-nameservers 8.8.8.8 8.8.4.4"
 
 # /dev/sda (gpt)
 # 1 - boot


### PR DESCRIPTION
Override resolver provider by DHCP as there are intermittent failures,
often when cloning a git repo or submodules of a git repo.