### PR TITLE
Fetch tempest junit report for archival/interpretation by Jenkins

### DIFF
--- a/playbooks/commit-multinode.yml
+++ b/playbooks/commit-multinode.yml
@@ -64,14 +64,22 @@
       script_env:
         DEPLOY_TEMPEST: "yes"
 
-## --------- [ Test with tempest ] ---------------
-- hosts: infrastructure[0]
-  tags: test
-  roles:
-    - role: run-script-from-os-ansible-deployment
-      script_name: run-tempest
-      script_env:
-        TEMPEST_SCRIPT_PARAMETERS: commit_aio
+## --------- [ Retrieve tempest report ] ---------------
+
+# The results file cannot be retrieved directly from the utility container as
+# the jenkins-rpc inventory does not include containers.
+# osad/scripts/run-tempest.sh copies tempest_results from the utility container
+# to /tmp on the host.  This play copies tempest_results from the deployment
+# host to the jenkins workspace.
+- hosts: infrastructure
+  tags: get_tempest_report
+  tasks:
+    - name: Get tempest results report
+      fetch:
+        src: /tmp/tempest_results.xml
+        dest: results/
+        flat: yes
+        fail_on_missing: no
 
 ## --------- [ Clean up nodes] ---------------
 - hosts: all

--- a/scripts/commit-multinode.sh
+++ b/scripts/commit-multinode.sh
@@ -69,10 +69,14 @@ run_jenkins_rpc_playbook_tag(){
     commit-multinode.yml
 }
 
-ssh_command(){
+get_infra_1_ip(){
   #Find the first node ip from the inventory
-  [[ -z $infra_1_ip ]] && infra_1_ip=$(grep -o -m 1 '10.127.[0-9]\+.[0-9]\+' \
-                          < inventory/commit-cluster-$CLUSTER_NUMBER)
+  grep -o -m 1 '10.127.[0-9]\+.[0-9]\+' \
+    < inventory/commit-cluster-$CLUSTER_NUMBER
+}
+
+ssh_command(){
+  infra_1_ip=$(get_infra_1_ip)
   : >> /tmp/env
   scp script_env $infra_1_ip:/tmp/env
   echo "Running command ${1}"
@@ -96,6 +100,9 @@ run(){
 test(){
   echo "export TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS}" > script_env
   ssh_osad_script run-tempest
+
+  # Get junit xml results from tempest so they can be interpreted by jenkins
+  run_jenkins_rpc_playbook_tag get_tempest_report
 }
 
 clean(){
@@ -148,6 +155,7 @@ write_properties(){
     done
   } > properties
 }
+
 
 ### -------------- [ Main ] --------------------
 


### PR DESCRIPTION
After tempest run, fetch the results file for interpretation by jenkins.

Generation of the report is covered by OSAD patch: https://review.openstack.org/#/c/191103/1

Needs Backport