### PR TITLE
added undefine to compute teardown to truly remove vms from virsh

### DIFF
--- a/playbooks/roles/teardown-compute-node/tasks/nova.yml
+++ b/playbooks/roles/teardown-compute-node/tasks/nova.yml
@@ -13,6 +13,11 @@
   with_items: instances.list_vms
   ignore_errors: yes
 
+- name: Undefine VMs
+  virt: name={{ item }} command=undefine
+  with_items: instances.list_vms
+  ignore_errors: yes
+
 - name: Uninstall nova and python-neutronclient
   pip: name={{ item }} state=absent
   with_items:


### PR DESCRIPTION
(cherry picked from commit 556e0a2f9fa0b127032559dadcfda24ae33b1504)