### PR TITLE
[kilo] Remove 'openstack_repo_url' reference

### DIFF
--- a/playbooks/vars/nightly-juno.yml
+++ b/playbooks/vars/nightly-juno.yml
@@ -64,7 +64,7 @@ swift_config:
   weight: 100
   min_part_hours: 1
   repl_number: 3
-  storage_network: 'br-storage' 
+  storage_network: 'br-storage'
   replication_network: 'br-repl'
   drives:
     - name: swift1

--- a/playbooks/vars/nightly-kilo.yml
+++ b/playbooks/vars/nightly-kilo.yml
@@ -1,7 +1,6 @@
 # repo configuration info
 config_prefix: openstack
 repo_dir: openstack_repo
-repo_url: https://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 
 # private cloud user config

--- a/playbooks/vars/nightly-master.yml
+++ b/playbooks/vars/nightly-master.yml
@@ -1,7 +1,6 @@
 # repo / dir info
 config_prefix: openstack
 repo_dir: openstack_repo
-repo_url: https://rpc-repo.rackspace.com
 razor_url: http://10.127.101.82:8080/api
 
 # rpc user config info

--- a/playbooks/vars/release-eng-iad3-lab02.yml
+++ b/playbooks/vars/release-eng-iad3-lab02.yml
@@ -1,7 +1,6 @@
 ---
 config_prefix: openstack
 repo_dir: os-ansible-deployment
-# repo_url: http://rpc-repo.rackspace.com
 
 user_config:
     container_cidr: 172.29.236.0/22

--- a/playbooks/vars/release-fcfs-iad3-lab03.yml
+++ b/playbooks/vars/release-fcfs-iad3-lab03.yml
@@ -1,7 +1,6 @@
 ---
 config_prefix: openstack
 repo_dir: os-ansible-deployment
-# repo_url: http://rpc-repo.rackspace.com
 
 user_config:
     container_cidr: 172.27.236.0/22

--- a/playbooks/vars/release-qe-iad3-lab01.yml
+++ b/playbooks/vars/release-qe-iad3-lab01.yml
@@ -1,7 +1,6 @@
 ---
 config_prefix: openstack
 repo_dir: rpc_repo
-repo_url: https://rpc-repo.rackspace.com
 
 user_config:
     container_cidr: 172.29.236.0/22


### PR DESCRIPTION
Pip repositories are now built within OSAD. Therefore, we don't need this variable anymore.