### PR TITLE
Change MaaS default

### DIFF
--- a/scripts/multinode.sh
+++ b/scripts/multinode.sh
@@ -140,7 +140,6 @@ function main {
     OSAD_REPO_DIR="${PRODUCT_REPO_DIR}/os-ansible-deployment"
 
     if [[ "${LAB_PREFIX}" == "release" ]]; then
-      DEPLOY_MAAS="yes"
       DEPLOY_HAPROXY="no"
     fi
 


### PR DESCRIPTION
This allows the `DEPLOY_MAAS` variable to be overridden within a Jenkins job. This needs to be present for `rpc-openstack` builds to complete successfully within IAD environments.