### PR TITLE
Remove pip's configuration directory across nodes

### DIFF
--- a/playbooks/multinode.yml
+++ b/playbooks/multinode.yml
@@ -143,6 +143,15 @@
     - rekick
   gather_facts: no
   roles:
+    - teardown-pip
+
+- hosts: all
+  user: root
+  tags:
+    - cleanup
+    - rekick
+  gather_facts: no
+  roles:
     - cleanup-host
 
 ## --------- [ Rekick Cluster ] ------------------

--- a/playbooks/roles/teardown-pip/tasks/main.yml
+++ b/playbooks/roles/teardown-pip/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Remove pip configuration directory
+  file:
+    path: ~/.pip
+    state: absent


### PR DESCRIPTION
Keeping these directories has caused issues on the Compute and Storage nodes within our release laboratories.

It's better to remove them entirely and let OSAD's `pip_lock_down` role take care of repopulating them.