### PR TITLE
Fix rpc variable merge

### DIFF
--- a/playbooks/multinode.yml
+++ b/playbooks/multinode.yml
@@ -45,9 +45,6 @@
   user: root
   gather_facts: yes
   tags:
-    - nightly
-    - commit
-    - prepare
     - cinder-volume
   roles:
     - volumes
@@ -56,9 +53,6 @@
   user: root
   gather_facts: yes
   tags:
-    - nightly
-    - commit
-    - prepare
     - configure-swift-lvs
   roles:
     - configure-swift-lvs

--- a/playbooks/roles/configure-compute/templates/user_config.j2
+++ b/playbooks/roles/configure-compute/templates/user_config.j2
@@ -17,27 +17,22 @@ environment_version: {{ environment_version.stat.md5 }}
 cidr_networks:
   # CIDR used in the Management network
   container: {{ user_config.container_cidr }}
-
 {% if user_config.tunnel_cidr is defined %}
   # CIDR used for the VM network
   tunnel: {{ user_config.tunnel_cidr }}
 {% endif %}
-
 {% if user_config.service_cidr is defined %}
   # CIDR used for the service network
   snet: {{ user_config.service_cidr}}
 {% endif %}
-
 {% if user_config.storage_cidr is defined %}
   # CIDR used for the storage network
   storage: {{ user_config.storage_cidr }}
 {% endif %}
-
 {% if user_config.repl_cidr is defined %}
   # CIDR used for the replication network
   repl: {{ user_config.repl_cidr }}
 {% endif %}
-
 {% if user_config.used_ips is defined %}
 used_ips:
 {% for used_ip_range in user_config.used_ips %}
@@ -54,10 +49,10 @@ global_overrides:
   # External DMZ VIP address
   external_lb_vip_address: {{ user_config.external_lb_vip_address }}
 
-  {% if user_config.tunnel_bridge is defined %}
+{% if user_config.tunnel_bridge is defined %}
   # Bridged interface to use with tunnel type networks
   tunnel_bridge: "{{ user_config.tunnel_bridge }}"
-  {% endif %}
+{% endif %}
 
   # Bridged interface to build containers with
   management_bridge: "{{ user_config.container_bridge }}"

--- a/playbooks/roles/configure-rpc/tasks/main.yml
+++ b/playbooks/roles/configure-rpc/tasks/main.yml
@@ -1,3 +1,17 @@
 ---
-- name: Copy RPC configuration files
-  shell: "cp --recursive {{ product_repo_dir }}/rpcd/etc/{{ config_prefix }}_deploy/* /etc/{{ config_prefix }}_deploy/"
+- name: Copy RPC rpcd/etc configuration files
+  shell: "cp {{ product_repo_dir }}/rpcd/etc/{{ config_prefix }}_deploy/{{ item }} /etc/{{ config_prefix }}_deploy/"
+  with_items:
+    - user_extras_secrets.yml
+    - user_extras_variables.yml
+
+- name: Copy RPC rpcd/env.d variable files
+  shell: "cp {{ product_repo_dir }}/rpcd/etc/{{ config_prefix }}_deploy/env.d/* /etc/{{ config_prefix }}_deploy/env.d/"
+
+- name: Copy RPC rpcd/conf.d configuration files
+  shell: "cp {{ product_repo_dir }}/rpcd/etc/{{ config_prefix }}_deploy/conf.d/* /etc/{{ config_prefix }}_deploy/conf.d/"
+
+- name: Merge RPC user_varibles.yml file with OSA user_variables.yml file
+  shell: "{{ product_repo_dir }}/scripts/update-yaml.py /etc/{{ config_prefix }}_deploy/{{ item }} {{ product_repo_dir }}/rpcd/etc/{{ config_prefix }}_deploy/{{ item }}"
+  with_items:
+    - user_variables.yml

--- a/playbooks/roles/configure-swift/templates/swift.j2
+++ b/playbooks/roles/configure-swift/templates/swift.j2
@@ -2,40 +2,40 @@
 {% set infra = groups['infrastructure'] %}
 {% set swift = groups['swift'] %}
 global_overrides:
-    swift:
-      part_power: {{ swift_config.part_power }}
-      weight: {{ swift_config.weight }}
-      repl_number: {{ swift_config.repl_number }}
-      min_part_hours: {{ swift_config.min_part_hours }}
+  swift:
+    part_power: {{ swift_config.part_power }}
+    weight: {{ swift_config.weight }}
+    repl_number: {{ swift_config.repl_number }}
+    min_part_hours: {{ swift_config.min_part_hours }}
 {% if swift_config.region is defined %}
-      region: {{ swift_config.region }}
+    region: {{ swift_config.region }}
 {% endif %}
 {% if swift_config.storage_network is defined %}
-      storage_network: '{{ swift_config.storage_network }}'
+    storage_network: '{{ swift_config.storage_network }}'
 {% endif %}
 {% if swift_config.replication_network is defined %}
-      replication_network: '{{ swift_config.replication_network }}'
+    replication_network: '{{ swift_config.replication_network }}'
 {% endif %}
-      drives:
+    drives:
 {% for drive in swift_config.drives %}
-        - name: {{ drive.name }}
+      - name: {{ drive.name }}
 {% endfor %}
-      mount_point: {{ swift_config.mount_point }}
-      account: {{ swift_config.account }}
-      container: {{ swift_config.container }}
-      storage_policies:
+    mount_point: {{ swift_config.mount_point }}
+    account: {{ swift_config.account }}
+    container: {{ swift_config.container }}
+    storage_policies:
 {% for storage_policy in swift_config.storage_policies %}
-        - policy:
-            name: {{ storage_policy.name }}
-            index: {{ storage_policy.index }}
+      - policy:
+          name: {{ storage_policy.name }}
+          index: {{ storage_policy.index }}
 {% if storage_policy.default is defined %}
-            default: {{ storage_policy.default }}
+          default: {{ storage_policy.default }}
 {% endif %}
 {% if storage_policy.repl_number is defined %}
-            repl_number: {{ storage_policy.repl_number }}
+          repl_number: {{ storage_policy.repl_number }}
 {% endif %}
 {% if storage_policy.depreciated is defined %}
-            depreciated: {{ storage_policy.depreciated }}
+          depreciated: {{ storage_policy.depreciated }}
 {% endif %}
 {% endfor %}
 
@@ -43,21 +43,21 @@ swift-proxy_hosts:
 {% for host in infra %}
   {{ host }}:
     ip: {{ hostvars[host]["ansible_ssh_host"] }}
-      container_vars:
-        swift_proxy_vars:
-          read_affinity: 'r{{ swift_config.region }}=100'
-          write_affinity: 'r{{ swift_config.region }}'
-          write_affinity_node_count: '2 * replicas'
+    container_vars:
+      swift_proxy_vars:
+        read_affinity: 'r{{ swift_config.region }}=100'
+        write_affinity: 'r{{ swift_config.region }}'
+        write_affinity_node_count: '2 * replicas'
 {% endfor %}
 
 swift_hosts:
 {% for host in swift %}
   {{ host }}:
     ip: {{ hostvars[host]["ansible_ssh_host"] }}
-      container_vars:
-        swift_vars:
-          zone: {{ hostvars[host]["zone"] }}
+    container_vars:
+      swift_vars:
+        zone: {{ hostvars[host]["zone"] }}
 {% if swift_config.region is defined %}
-          region: {{ swift_config.region }}
-{{% endif %}}
+        region: {{ swift_config.region }}
+{% endif %}
 {% endfor %}

--- a/playbooks/roles/configure-swift/templates/swift.j2
+++ b/playbooks/roles/configure-swift/templates/swift.j2
@@ -7,7 +7,9 @@ global_overrides:
       weight: {{ swift_config.weight }}
       repl_number: {{ swift_config.repl_number }}
       min_part_hours: {{ swift_config.min_part_hours }}
-      region: '{{ swift_config.region }}'
+{% if swift_config.region is defined %}
+      region: {{ swift_config.region }}
+{% endif %}
 {% if swift_config.storage_network is defined %}
       storage_network: '{{ swift_config.storage_network }}'
 {% endif %}
@@ -55,5 +57,7 @@ swift_hosts:
       container_vars:
         swift_vars:
           zone: {{ hostvars[host]["zone"] }}
-          region: '{{ swift_config.region }}'
+{% if swift_config.region is defined %}
+          region: {{ swift_config.region }}
+{{% endif %}}
 {% endfor %}


### PR DESCRIPTION
I fixed the way that RPC config files get laid down and updated to mirror the docs. I also removed tags from the cinder lvm config task and swift-lvs task as these should be passed if you want them run, not on prepare everytime