### PR TITLE
Build-Summary: fix find next task

### DIFF
--- a/scripts/build-summary/build.py
+++ b/scripts/build-summary/build.py
@@ -252,7 +252,11 @@ class Build(object):
     def get_previous_task(self, line, lines, order=-1, get_line_num=False):
         previous_task_re = re.compile(
             'TASK: \[((?P<role>.*)\|)?(?P<task>.*)\]')
-        for index in range(line, 0, order):
+        if order == -1:
+            end = 0
+        else:
+            end = len(lines)
+        for index in range(line, end, order):
             match = previous_task_re.search(lines[index])
             if match:
                 gd = match.groupdict()


### PR DESCRIPTION
When looking for the next task instead of the previous task, then end
point as well as the increment must be changed.