### PR TITLE
Add upgrade parent job script

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -128,23 +128,35 @@ if [ "$UPGRADE" == "yes" ] && [ "$OVERALL_RESULT" -eq 0 ];
       exit 1
     }
     git submodule update --init
-
     echo "********************** Run RPC Deploy Script ***********************"
-
-    sudo \
-      TERM=linux \
-      DEPLOY_AIO=no \
-      DEPLOY_HAPROXY=yes \
-      DEPLOY_TEMPEST=yes \
-      DEPLOY_CEPH=${DEPLOY_CEPH} \
-      DEPLOY_SWIFT=${DEPLOY_SWIFT} \
-      DEPLOY_MAAS=${DEPLOY_MAAS} \
-      ANSIBLE_GIT_RELEASE=ssh_retry \
-      ANSIBLE_GIT_REPO="https://github.com/hughsaunders/ansible" \
-      ADD_NEUTRON_AGENT_CHECKSUM_RULE=yes \
-      BOOTSTRAP_OPTS=$BOOTSTRAP_OPTS \
-      scripts/upgrade.sh
-
+    if [[ "$UPGRADE_TYPE" == "major" ]]; then
+      sudo \
+        TERM=linux \
+        DEPLOY_AIO=no \
+        DEPLOY_HAPROXY=yes \
+        DEPLOY_TEMPEST=yes \
+        DEPLOY_CEPH=${DEPLOY_CEPH} \
+        DEPLOY_SWIFT=${DEPLOY_SWIFT} \
+        DEPLOY_MAAS=${DEPLOY_MAAS} \
+        ANSIBLE_GIT_RELEASE=ssh_retry \
+        ANSIBLE_GIT_REPO="https://github.com/hughsaunders/ansible" \
+        ADD_NEUTRON_AGENT_CHECKSUM_RULE=yes \
+        BOOTSTRAP_OPTS=$BOOTSTRAP_OPTS \
+        scripts/upgrade.sh
+    else
+      sudo \
+        DEPLOY_AIO=yes \
+        DEPLOY_HAPROXY=yes \
+        DEPLOY_TEMPEST=yes \
+        DEPLOY_CEPH=${DEPLOY_CEPH} \
+        DEPLOY_SWIFT=${DEPLOY_SWIFT} \
+        DEPLOY_MAAS=${DEPLOY_MAAS} \
+        ANSIBLE_GIT_RELEASE=ssh_retry \
+        ANSIBLE_GIT_REPO="https://github.com/hughsaunders/ansible" \
+        ADD_NEUTRON_AGENT_CHECKSUM_RULE=yes \
+        BOOTSTRAP_OPTS=$BOOTSTRAP_OPTS \
+        scripts/deploy.sh
+    fi
     DEPLOY_RC=$?
 
     echo "********************** Run Tempest ***********************"

--- a/scripts/dev-aio-upgrade/upgrade-parent-job.sh
+++ b/scripts/dev-aio-upgrade/upgrade-parent-job.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+rm -rf rpc-openstack
+git clone --recursive $RPC_REPO
+
+pushd rpc-openstack
+  echo "UPGRADE_PATHS=$(../jenkins-rpc/scripts/dev-aio-upgrade/upgrade-branches.sh|tr '\n' ' ' )"\
+    > ../upgrade.properties
+popd


### PR DESCRIPTION
Script added here so that as little as possible is in the actual jenkins
config. This script takes the output of upgrade branches, converts
references to absolute and writes a properties file which will be fed to
the matrix job for generating the dynamic axis.

Also changed the delimiter used by upgrade-branches from - to _ as some
branch names contain -.