### PR TITLE
Add logging of MaaS entities

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -159,6 +159,12 @@ if [ "$UPGRADE" == "yes" ] && [ "$OVERALL_RESULT" -eq 0 ];
     OVERALL_RESULT=$?
 
 fi
+# There are a number of AIO failures due the MaaS entity being missing.
+# This is to validate the playbooks are failing correctly.
+if [ "$DEPLOY_MAAS" == "yes" ]
+then
+  raxmon-entities-list --debug
+fi
 echo "Ansible Result: $DEPLOY_RC"
 echo "Tempest Result: $TEMPEST_RC"
 echo "Overall Result: $OVERALL_RESULT"


### PR DESCRIPTION
There are regular rpc_maas failures due to the entity being missing. The
purpose of this change is to capture the list of available entities to
validate that the entity was not created when the instance was
provisioned.