### PR TITLE
Only rebase when ghprbTargetBranch is supplied.

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -122,11 +122,13 @@ if [ "$UPGRADE" == "yes" ] && [ "$OVERALL_RESULT" -eq 0 ];
 
     git stash
     git checkout ${sha1}
-    echo "Rebasing ${sha1} on ${ghprbTargetBranch}"
-    git rebase origin/${ghprbTargetBranch} || {
-      echo "Rebase failed, quitting"
-      exit 1
-    }
+    if [[ ! -z "${ghprbTargetBranch}" ]]; then
+      echo "Rebasing ${sha1} on ${ghprbTargetBranch}"
+      git rebase origin/${ghprbTargetBranch} || {
+        echo "Rebase failed, quitting"
+        exit 1
+      }
+    fi
     git submodule update --init
     echo "********************** Run RPC Deploy Script ***********************"
     if [[ "$UPGRADE_TYPE" == "major" ]]; then


### PR DESCRIPTION
The AIO job potentially does two deploys - the initial and the upgrade.

The initial deploy is rebased if the job is not an upgrade.
The upgrade deploy is currently always rebased. This script changes the
upgrade deploy rebase to be conditional on ghprbTargetBranch not being
"".