### PR TITLE
Sync submodules

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -40,6 +40,7 @@ else
     }
 fi
 
+git submodule sync
 git submodule update --init
 
 # git plugin checks out repo to root of workspace
@@ -129,6 +130,7 @@ if [ "$UPGRADE" == "yes" ] && [ "$OVERALL_RESULT" -eq 0 ];
         exit 1
       }
     fi
+    git submodule sync
     git submodule update --init
     echo "********************** Run RPC Deploy Script ***********************"
     if [[ "$UPGRADE_TYPE" == "major" ]]; then


### PR DESCRIPTION
If a submodule URL is updated in .gitmodules by a patch being tested or
between versions being used for an upgrade test the submodule's URL in
.git/config is not updated.

This commit adds 'git submodule sync' to the build script so that
.git/config is correct prior to updating the submodules.