### PR TITLE
Build summary: Add a couple of failures and improve failure list

### DIFF
--- a/scripts/build-summary/buildsummary.j2
+++ b/scripts/build-summary/buildsummary.j2
@@ -188,7 +188,13 @@ $(document).ready( function () {
         {% if buildobj.gh_pull %}
         PR#<a href="https://github.com/rcbops/rpc-openstack/pull/{{buildobj.gh_pull|default("")}}">{{buildobj.gh_pull|default("")}}:{{buildobj.gh_title|default("")}} {{buildobj.commit}} </a></td>
         {% endif %}
-      <td><a href="http://jenkins.propter.net/job/{{buildobj.job_name}}/{{buildobj.build_num}}/consoleFull">{{buildobj.failures|join(" ")}}</a></td>
+        <td>
+            <ul>
+              {% for fail in buildobj.failures %}
+              <li><a href="http://jenkins.propter.net/job/{{buildobj.job_name}}/{{buildobj.build_num}}/consoleFull">{{fail}}</a></li>
+              {% endfor %}
+            </ul>
+        </a></td>
     </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
- Add matchers for missing pip packages and apt hash sum mismatch.
- Turn failures cell of recent results table into a structured list for easier reading when multiple failures are reported on the same job. 
