### PR TITLE
Merge in Defcore and MaaS results.

### DIFF
--- a/scripts/build-summary/build.py
+++ b/scripts/build-summary/build.py
@@ -35,12 +35,8 @@ class Build(object):
         self.commit = self.env_vars.get('ghprbActualCommit', '')
         if self.env_vars.get('DEPLOY_CEPH') == 'yes':
             self.btype = 'ceph'
-        elif self.env_vars.get('DEPLOY_MAAS') == 'yes':
-            self.btype = 'maas'
         elif self.env_vars.get('HEAT_TEMPLATE', ''):
             self.btype = 'multinode'
-        elif 'defcore' in self.env_vars.get('TEMPEST_TESTS', ''):
-            self.btype = 'defcore'
         else:
             self.btype = 'full'
         self.get_parent_info()

--- a/scripts/build-summary/buildsummary.j2
+++ b/scripts/build-summary/buildsummary.j2
@@ -123,16 +123,6 @@ $(document).ready( function () {
         {{ mcell('kilo_ceph_periodic') }}
       </tr>
       <tr>
-        <th>Defcore</th>
-        {{ mcell('master_defcore_periodic') }}
-        {{ mcell('kilo_defcore_periodic') }}
-      </tr>
-      <tr>
-        <th>MaaS</th>
-        {{ mcell('master_maas_periodic') }}
-        {{ mcell('kilo_maas_periodic') }}
-      </tr>
-      <tr>
         <th>Heat Multinode</th>
         {{ mcell('master_multinode_periodic') }}
         <td>N/A</td>


### PR DESCRIPTION
All jobs now deploy MaaS and run the defcore test set, so there is no
need for seperate reporting