### PR TITLE
Revert "Add logging of MaaS entities"

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -181,12 +181,6 @@ if [ "$UPGRADE" == "yes" ] && [ "$OVERALL_RESULT" -eq 0 ];
     OVERALL_RESULT=$?
 
 fi
-# There are a number of AIO failures due the MaaS entity being missing.
-# This is to validate the playbooks are failing correctly.
-if [ "$DEPLOY_MAAS" == "yes" ]
-then
-  raxmon-entities-list --debug
-fi
 echo "Ansible Result: $DEPLOY_RC"
 echo "Tempest Result: $TEMPEST_RC"
 echo "Overall Result: $OVERALL_RESULT"


### PR DESCRIPTION
This reverts commit ac4194c1ad5c8add19c49939e6f49febd9980a88.

This commit does not function as intended due to how the credentials are
supplied and so is being removed.