### PR TITLE
Remove use of sudo when updating variables file

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -112,7 +112,7 @@ sudo sed -i '/rackspace_cloud_\(auth_url\|tenant_id\|username\|password\|api_key
 echo "Adding MAAS creds to user_extras_variables"
 #set +x to avoid leaking creds to the log.
 set +x
-sudo tee -a $uev &>/dev/null <<EOVARS
+tee -a $uev &>/dev/null <<EOVARS
 ---
 rackspace_cloud_auth_url: ${rackspace_cloud_auth_url}
 rackspace_cloud_tenant_id: ${rackspace_cloud_tenant_id}
@@ -123,7 +123,7 @@ EOVARS
 set -x
 
 #Supply fixed cirros image while empty key bug is not fixed upstream.
-sudo tee -a $uev &>/dev/null <<EOVARS
+tee -a $uev &>/dev/null <<EOVARS
 cirros_img_url: "http://rpc-repo.rackspace.com/rpcgating/cirros-0.3.4-x86_64-dropbearmod.img"
 tempest_images:
   - url: "{{cirros_img_url}}"


### PR DESCRIPTION
The commit bfd4dbb5bc0df7d5a0b14753637d71dffabeee52 introduced the use
of a new file, user_zzz_gating_variables.yml, as the place for Jenkins
to set any job-specific Ansible variables. This file, unlike the
previously used one, user_extras_variables.yml, does not exist by
default. When aio_build_script.sh attempted to modify it, this caused it
to be created with sudo, causing it to be owned by
root, which meant that a later command was failing when trying to modify
the file without using sudo. The result of this is that the build does
not have all the expected variables set.

This commit removes the use of sudo so that the file is owned by the
user jenkins and group wheel.