### PR TITLE
Fix "Cannot set property '_DT_CellIndex' ..."

### DIFF
--- a/scripts/build-summary/buildsummary.j2
+++ b/scripts/build-summary/buildsummary.j2
@@ -140,6 +140,7 @@ $(document).ready( function () {
       </tr>
       <tr>
         <th>Heat Multinode</th>
+        <td>N/A</td>
         {{ mcell('master_multinode_periodic') }}
         <td>N/A</td>
       </tr>


### PR DESCRIPTION
This was caused by a missing cell in the heat multinode row.