### PR TITLE
Show multinode results as master.

### DIFF
--- a/scripts/build-summary/buildsummary.j2
+++ b/scripts/build-summary/buildsummary.j2
@@ -140,8 +140,8 @@ $(document).ready( function () {
       </tr>
       <tr>
         <th>Heat Multinode</th>
-        <td>N/A</td>
         {{ mcell('master_multinode_periodic') }}
+        <td>N/A</td>
         <td>N/A</td>
       </tr>
     </tbody>


### PR DESCRIPTION
While the template in use is rpc-12, the rpc sha is overridden to
master, so the result should be shown in the master column.