### PR TITLE
Keeupundefinedparamters

### DIFF
--- a/dockerfiles/jenkins/Dockerfile
+++ b/dockerfiles/jenkins/Dockerfile
@@ -35,4 +35,4 @@ ENV JENKINS_HOME /opt/jenkins
 VOLUME /opt/jenkins
 
 # Fire up jenkins
-CMD java -jar /opt/jenkins/jenkins.war
+CMD java -Dhudson.model.ParametersAction.keepUndefinedParameters=true -jar opt/jenkins/jenkins.war


### PR DESCRIPTION
Jenkins change SECURITY-170 introduces a change that prevents jobs from
receving undefined parameters into their environment.

The current RPC job set relies on parameters from the github pull
request trigger, some of which are not defined as job parameters. This
patch sets jenkins back to the old behaviour, which gives us time to
change the jobs inline with the new standard.