### PR TITLE
Fix the horizon extensions override

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -140,6 +140,7 @@ if [[ -e horizon-extensions && -n "${ghprbAuthorRepoGitUrl}" && -n "${ghprbActua
   tee -a $uev &>/dev/null <<EOVARS
 horizon_extensions_git_repo: ${ghprbAuthorRepoGitUrl}
 horizon_extensions_git_install_branch: ${ghprbActualCommit}
+horizon_extensions_git_install_fragments: "subdirectory=horizon-extensions/"
 EOVARS
 fi
 


### PR DESCRIPTION
The horizon extension override in the user_variables doesn't
override the subfolder. Due to the way the py_pkg lookup works,
all the variables that need to be overriden have to be specified
in the user_variables file.