### PR TITLE
Added gating testing for holland venv

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -41,7 +41,14 @@ run_tempest(){
 }
 run_holland(){
   echo "********************** Run Holland  ***********************"
-  sudo lxc-attach -n $(sudo lxc-ls |grep galera|head -n1) -- /bin/bash -c "holland bk"
+  # Move test_holland.yml playbook to rpc-openstack repo
+  cp buildscript_repo/scripts/test_holland.yml /opt/rpc-openstack/rpcd/playbooks
+  # Run the playbook
+  pushd /opt/rpc-openstack/rpcd/playbooks
+    sudo -E openstack-ansible test_holland.yml
+  popd
+  # Remove the playbook
+  rm /opt/rpc-openstack/rpcd/playbooks/test_holland.yml
   echo "********************** Holland Completed Succesfully ***********************"
 }
 

--- a/scripts/test_holland.yml
+++ b/scripts/test_holland.yml
@@ -1,0 +1,24 @@
+---
+
+- hosts: galera
+  user: root
+  vars:
+    holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
+  tasks:
+    - name: Discover rpc-openstack version
+      git_repo_info:
+        path: "/opt/rpc-openstack"
+      delegate_to: localhost
+      run_once: true
+      tags:
+        - rpc-release
+    
+    - name: Test for holland venv
+      stat: 
+        path: "{{ holland_venv_bin }}"
+      register: holland_venv
+
+    - name: Test the functionality of the holland bk command
+      register: command_result
+      failed_when: "command_result.rc > 0"
+      command: "{{ holland_venv.stat.exists | bool | ternary(holland_venv_bin + '/python2.7', '') }} {{ holland_venv.stat.exists | bool | ternary(holland_venv_bin + '/', '') }}holland bk"


### PR DESCRIPTION
Jenkins pulls venv realted variables from the appropriate Ansible
playbooks and executes holland from its venv if that is enabled

Connects rcbops/rpc-openstack#1215