### PR TITLE
Fix the horizon extensions override (redux)

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -141,6 +141,7 @@ if [[ -e horizon-extensions && -n "${ghprbAuthorRepoGitUrl}" && -n "${ghprbActua
 horizon_extensions_git_repo: ${ghprbAuthorRepoGitUrl}
 horizon_extensions_git_install_branch: ${ghprbActualCommit}
 horizon_extensions_git_install_fragments: "subdirectory=horizon-extensions/"
+horizon_extensions_git_package_name: "horizon-extensions"
 EOVARS
 fi
 


### PR DESCRIPTION
We forgot to add the git package name, so it's considered as
another egg for the py_pkg lookup.

This should fix it.

Connects rcbops/u-suk-dev#259