### PR TITLE
Fix aio_build_script.sh with unset vars

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -143,7 +143,9 @@ set -x
 # rebased or merged into master before being built. So if the proposed commit's
 # parent is old, this test won't guarantee that it works with the current
 # master.
-if [[ -e horizon-extensions && -n "${ghprbAuthorRepoGitUrl}" && -n "${ghprbActualCommit}" ]]; then
+if [[ -n "${ghprbAuthorRepoGitUrl:-}" && -n "${ghprbActualCommit:-}" ]]\
+      && git ls-tree ${ghprbActualCommit} --name-only \
+           | grep -q horizon-extensions; then
   tee -a $uev &>/dev/null <<EOVARS
 horizon_extensions_git_repo: ${ghprbAuthorRepoGitUrl}
 horizon_extensions_git_install_branch: ${ghprbActualCommit}


### PR DESCRIPTION
An issue appears when ghprbAuthorRepoGitUrl or ghprbActualCommit
are not set, due to the presence of set -u in L3.

The condition used for horizon extensions was causing this, because
the variables above are only set for PRs, not periodic jobs.

This commit fixes the condition used.

Connects rcbops/u-suk-dev#260

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>
Co-Authored-By: Hugh Saunders <hugh.saunders@rackspace.co.uk>