### PR TITLE
Remove unnecessary BOOTSTRAP_OPTS pass throughs

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -21,13 +21,9 @@ run_rpc_deploy(){
     DEPLOY_AIO=yes \
     DEPLOY_HAPROXY=yes \
     DEPLOY_TEMPEST=yes \
-    DEPLOY_CEPH=${DEPLOY_CEPH} \
-    DEPLOY_SWIFT=${DEPLOY_SWIFT} \
-    DEPLOY_MAAS=${DEPLOY_MAAS} \
     ANSIBLE_GIT_RELEASE=ssh_retry \
     ANSIBLE_GIT_REPO="https://github.com/hughsaunders/ansible" \
     ADD_NEUTRON_AGENT_CHECKSUM_RULE=yes \
-    BOOTSTRAP_OPTS=$BOOTSTRAP_OPTS \
     scripts/$script
   echo "********************** RPC $script Completed Succesfully ***********************"
 }


### PR DESCRIPTION
These lines are not necessary as sudo -E will preserve the envionment.
The BOOTSTRAP_OPTS line was preventing the BOOTSTRAP_OPTS var from being
passed from jenkins-rpc/aio_build_script to
rpc-openstack/scripts/deploy.sh because it had a leading space but
wasn't quoted.

Connects rcbops/u-suk-dev#263