### PR TITLE
Auto Select Mirror

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -106,7 +106,7 @@
     UPGRADE_FROM_REF: "origin/kilo"
     UPGRADE_FROM_NEAREST_TAG: "yes"
     UPGRADE_TYPE: "major"
-    UBUNTU_REPO: "https://mirror.rackspace.com/ubuntu"
+    UBUNTU_REPO: "auto"
     DEPLOY_MAAS: "yes"
     JENKINS_RPC_REPO: "https://github.com/rcbops/jenkins-rpc"
     JENKINS_RPC_BRANCH: "master"


### PR DESCRIPTION
Auto Select Mirror

If UBUNTU_MIRROR is unset or set to "auto"
Mirror list is from OSA, which uses the mirrors run by openstack infra.
Selection criteria is latency (time to load index page).

Depends rcbops/jenkins-rpc#632
Connects rcbops/u-suk-dev#300