### PR TITLE
Set upgrade type to Major for Jenkins-RPC tests

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -69,6 +69,7 @@
           predefined-parameters: |
             JENKINS_RPC_BRANCH=${{sha1}}
             UPGRADE={upgrade}
+            UPGRADE_TYPE=major
             sha1=liberty-12.2
             ghprbTargetBranch=liberty-12.2
 


### PR DESCRIPTION
PR Upgrade jobs are always major upgrades (previous major to current
commit), so the the UPGRADE_TYPE variable can be hard coded to major. If
UPGRADE=no,  then UPGRADE_TYPE will be ignored

Connects rcbops/u-suk-dev#310