### PR TITLE
Add Liberty-Mitaka Upgrade Job

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -88,6 +88,13 @@
           context: upgrade
           branches: "liberty-.*"
           UPGRADE: "yes"
+      - 'JJB-RPC-AIO_{series}-{context}':
+          series: mitaka
+          branch: "master" # TODO: Change to mitaka-13.1 on release.
+          context: upgrade
+          branches: "mitaka-13\\.[^0].*"
+          UPGRADE: "yes"
+          UPGRADE_FROM_REF: "origin/liberty-12.2"
 
 ## Job Definitions
 # This template is for testing PRs against Jenkins-RPC

--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -196,7 +196,9 @@ if [ "$UPGRADE" == "yes" ]; then
     override_oa
     log_git_status
     if [[ "$UPGRADE_TYPE" == "major" ]]; then
-      run_rpc_deploy upgrade.sh
+      # 13.0 renamed upgrade upgrade.sh to test-upgrade.sh
+      upgrade_script=$(basename scripts/*upgrade.sh)
+      run_rpc_deploy $upgrade_script
     else
       run_rpc_deploy
     fi


### PR DESCRIPTION
Add job for upgrading from liberty to mitaka. Periodics will start
immediately but PR jobs won't be run until 13.1 is released.

Connects rcbops/u-suk-dev#371