### PR TITLE
Stash OA changes before upgrade checkout

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -187,6 +187,7 @@ run_holland
 
 if [ "$UPGRADE" == "yes" ]; then
     git stash
+    git submodule foreach git stash
     git checkout ${sha1}
     if [[ ! -z "${ghprbTargetBranch:-}" ]]; then
       integrate_proposed_change


### PR DESCRIPTION
If the OA repo is dirty for any reason, checking out the verison to
upgrade to will fail. Previously changes in the rpc repo were stashed
but that didn't extend to submodules. This commit stashes changes for
all submodules.

Connects rcbops/u-suk-dev#371