### PR TITLE
Skip func test for doc-like changes

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -245,7 +245,7 @@
               # long stat widths specified to ensure paths aren't truncated
               git show --stat=400,400 origin/$sha1 \
                   |awk '/\|/{{print $1}}' \
-                  |egrep -v '*.md$' \
+                  |egrep -v -e '.*md$' -e '.*rst$' -e '^releasenotes/' \
                   || {{ echo "Skipping AIO build as no non-doc changes were detected"
                       prep_artefacts
                       exit 0


### PR DESCRIPTION
Release notes and rst files don't need to trigger full functional tests.

Connected: rcbops/u-suk-dev#408

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>