### PR TITLE
Back to rackspace mirror

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -113,7 +113,7 @@
     UPGRADE_FROM_REF: "origin/kilo"
     UPGRADE_FROM_NEAREST_TAG: "yes"
     UPGRADE_TYPE: "major"
-    UBUNTU_REPO: "auto"
+    UBUNTU_REPO: "http://mirror.rackspace.com/ubuntu"
     DEPLOY_MAAS: "yes"
     JENKINS_RPC_REPO: "https://github.com/rcbops/jenkins-rpc"
     JENKINS_RPC_BRANCH: "master"


### PR DESCRIPTION
Further work is required before the infra mirrors can be used because
they don't carry all the sections of the ubuntu repo.

Connects rcbops/u-suk-dev#482