### PR TITLE
Set HOME to /root

### DIFF
--- a/scripts/aio_build_script.sh
+++ b/scripts/aio_build_script.sh
@@ -217,6 +217,9 @@ export BOOTSTRAP_OPTS="${BOOTSTRAP_OPTS} bootstrap_host_ubuntu_security_repo=${U
 # Add any additional vars specified in jenkins job params
 echo "${USER_VARS:-}" | tee -a $uev
 
+# Explicitly set HOME variable
+export HOME=/root
+
 run_rpc_deploy
 run_tempest
 run_holland


### PR DESCRIPTION
References to /jenkins are still poping up from place to place,
causing periodic gate failures. This commit explicity sets
HOME to /root.

Related rcbops/u-suk-dev#488