### PR TITLE
Enable colours in logs

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -153,6 +153,7 @@
     logrotate:
       daysToKeep: 30
     wrappers:
+      - ansicolor
       - timestamps
       - credentials-binding:
         - text:


### PR DESCRIPTION
Ansible is outputing colour control codes, but jenkins isn't
interpreting them, so the logs are littered with non printing characters
which reduces readability.

This patch enables the jenkins plugin for interpeting colour control codes.

Connects rcbops/u-suk-dev#361