### PR TITLE
Add logstash JJB wrapper to job template

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -156,6 +156,8 @@
     logrotate:
       daysToKeep: 30
     wrappers:
+      - logstash:
+          use-redis: False
       - ansicolor
       - timestamps
       - credentials-binding:


### PR DESCRIPTION
The Logstash jenkins plugin will be used to send JSON payloads
about each job to an Elasticsearch cluster. For more
information, please see:
https://github.com/rcbops/u-suk-dev/issues/537

Connects https://github.com/rcbops/u-suk-dev/issues/537