### PR TITLE
Move misc jobs to JJB

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -113,6 +113,37 @@
           context: cidev
           CRON: ""
 
+- project:
+    name: 'JJB-Misc-Jobs'
+    jobs:
+      - 'JJB-Misc-{name}':
+          name: Build-Summary
+          shell: |
+            #!/bin/bash -x
+            . /opt/jenkins/venvs/buildsummary/bin/activate
+            cd scripts/build-summary
+            python build-summary-gh.py /opt/jenkins_builds/jobs/{{RPC-AIO,RPC-Training-Multinode,JJB-RPC-AIO*,JJB-Jenkins-RPC-PR*}}/builds/*/build.xml \
+                > /opt/jenkins/www/index_tmp.html \
+                && cp /opt/jenkins/www/index_tmp.html /opt/jenkins/www/index.html
+      - 'JJB-Misc-{name}':
+          name: AIO-Cleanup
+          shell: |
+            #!/bin/bash
+
+            source /opt/jenkins/creds/mattt_jenkins_iad
+            source /opt/jenkins/venvs/rpcheat/bin/activate
+            source /opt/jenkins/creds/jenkins_api_access.creds
+
+            python scripts/aio_cleanup.py
+      - 'JJB-Misc-{name}':
+          name: Multinode-Cleanup
+          shell: |
+            #!/bin/bash
+
+            set -x
+            set -e
+            bash scripts/heat_cleanup.sh
+
 
 ## Job Definitions
 # This template is for testing PRs against Jenkins-RPC
@@ -497,6 +528,28 @@
             UPGRADE_TYPE=major
             sha1=liberty-12.2
             ghprbTargetBranch=liberty-12.2
+
+- job-template:
+    name: "JJB-Misc-{name}"
+    display-name: "JJB-Misc-{name}"
+    project-type: freestyle
+    description: 'Managed by JJB: Misc {name}'
+    defaults: global
+    disabled: false
+    concurrent: false
+    node: master
+    logrotate:
+      numToKeep: 50
+    # NOTE(mattt): Is this property actually required here?
+    properties:
+      - jenkins-rpc-github
+    scm:
+      - jenkins-rpc-git
+    triggers:
+      - timed: "H/5 * * * *"
+    builders:
+      - shell: |
+          {shell}
 
 # Update Jenkins Jobs.
 # This job runs after changes are merged to jenkins-rpc.

--- a/scripts/aio_cleanup.py
+++ b/scripts/aio_cleanup.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import datetime
+import dateutil.parser
+import os
+import requests
+
+from novaclient import client
+
+nova = client.Client(
+    2,
+    username=os.environ['OS_USERNAME'],
+    api_key=os.environ['OS_PASSWORD'],
+    tenant_id=os.environ['OS_TENANT_NAME'],
+    auth_url=os.environ['OS_AUTH_URL'],
+    region_name="IAD"
+)
+
+jenkins_api_user = os.environ['JENKINS_API_USER']
+jenkins_api_pass = os.environ['JENKINS_API_PASS']
+
+slaves = requests.get("http://jenkins.propter.net/computer/api/json",
+                      auth=(jenkins_api_user, jenkins_api_pass)).json()['computer']
+slave_names = [x['displayName'] for x in slaves]
+print("Jenkins Slaves: %s" %slave_names)
+def jenkins_node(name):
+  return name in slave_names
+
+
+slaves=0
+instances=0
+for s in nova.servers.list():
+    created = dateutil.parser.parse(s.created)
+    sixhoursago = datetime.datetime.now(created.tzinfo)-datetime.timedelta(hours=6)
+    comingofage = datetime.datetime.now(created.tzinfo)-datetime.timedelta(minutes=7)
+    adult = created < comingofage
+    error = s.status == 'ERROR'
+    old = created < sixhoursago
+    is_slave = jenkins_node(s.name)
+    instances+=1
+    if is_slave:
+        slaves+=1
+    print("Instance:{name} slave:{slave} status:{status} adult:{adult} old:{old}".format(
+        name=s.name,
+        slave=is_slave,
+        status=s.status,
+        adult=adult,
+        old=old
+    ))
+    if (s.name.startswith('jrpcaio')
+            and (
+                s.status == 'ERROR'
+                or ((not is_slave) and adult)
+                or old
+            )):
+        print("Deleting %(name)s Error:%(error)s Old:%(old)s"
+              % dict(name=s.name, error=error, old=old))
+        s.delete()
+
+print("Slaves: {numslaves}, Instances that aren't active slaves: {non_slave_instances}".format(
+    numslaves=slaves,
+    non_slave_instances=instances-slaves))


### PR DESCRIPTION
This commit moves the following jobs defined manually in Jenkins to JJB:

- RPC-AIO Build Summary
- RPC-AIO Instance Cleanup
- RPC-Multinode-Cleanup

We also create a new file called scripts/aio_cleanup.py which is called
by one of the JJB jobs to avoid embedding this rather lenghty code into
JJB itself.

Connects https://github.com/rcbops/u-suk-dev/issues/352