### PR TITLE
Move logstash plugin to use post-build component

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -156,8 +156,6 @@
     logrotate:
       daysToKeep: 30
     wrappers:
-      - logstash:
-          use-redis: False
       - ansicolor
       - timestamps
       - credentials-binding:
@@ -459,6 +457,10 @@
       - junit:
           results: "archive/openstack/*_utility_*/*.xml"
           allow-empty-results: true
+      # Push logs over to logstash
+      - logstash:
+          max-lines: 70000
+          fail-build: false
 
 # This template has two variables - type and upgrade.
 - job-template:


### PR DESCRIPTION
This commit removes the logstash buildwrapper and adds the
logstash post-build publisher so logs are processed after
a build completes, and not on a line-by-line basis.

Connects https://github.com/rcbops/u-suk-dev/issues/540