### PR TITLE
Remove jenkins-rpc AIO jobs

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -37,17 +37,6 @@
       - string:
           name: GIT_BRANCH
 
-# This project instantiates the JJB-Jenkins-RPC-PR-{type} template twice
-# to create an aio and an upgrade job.
-- project:
-    name: JJB-Jenkins-RPC-PR-Jobs
-    jobs:
-      - 'JJB-Jenkins-RPC-PR-{type}':
-          type: "upgrade"
-          upgrade: "yes"
-      - 'JJB-Jenkins-RPC-PR-{type}':
-          type: "aio"
-          upgrade: "no"
 
 - project:
     name: 'JJB-AIO-Jobs'
@@ -122,7 +111,7 @@
             #!/bin/bash -x
             . /opt/jenkins/venvs/buildsummary/bin/activate
             cd scripts/build-summary
-            python build-summary-gh.py /opt/jenkins_builds/jobs/{{RPC-AIO,RPC-Training-Multinode,JJB-RPC-AIO*,JJB-Jenkins-RPC-PR*}}/builds/*/build.xml \
+            python build-summary-gh.py /opt/jenkins_builds/jobs/{{RPC-AIO,RPC-Training-Multinode,JJB-RPC-AIO*}}/builds/*/build.xml \
                 > /opt/jenkins/www/index_tmp.html \
                 && cp /opt/jenkins/www/index_tmp.html /opt/jenkins/www/index.html
       - 'JJB-Misc-{name}':
@@ -493,43 +482,6 @@
           max-lines: 70000
           fail-build: false
 
-# This template has two variables - type and upgrade.
-- job-template:
-    name: "JJB-Jenkins-RPC-PR-{type}"
-    display-name: "JJB-Jenkins-RPC-PR-{type}"
-    project-type: freestyle
-    description: 'Managed by JJB: Test changes to jenkins-rpc'
-    defaults: global
-    disabled: false
-    concurrent: true
-    node: master
-    logrotate:
-      daysToKeep: 30
-    properties:
-      - jenkins-rpc-github
-    scm:
-      - jenkins-rpc-git
-    triggers:
-      - github-pull-request:
-          org-list:
-            - rcbops
-          github-hooks: true
-          trigger-phrase: '.*recheck_all.*|.*recheck_{type}.*'
-          white-list-target-branches:
-            - master
-          auth-id: "8b635975-7d59-45f8-b7ee-8bceb2e44ba3"
-          status-context: "{type}"
-    builders:
-      - trigger-builds:
-        - project: "RPC-AIO"
-          block: true
-          current-parameters: False
-          predefined-parameters: |
-            JENKINS_RPC_BRANCH=${{sha1}}
-            UPGRADE={upgrade}
-            UPGRADE_TYPE=major
-            sha1=liberty-12.2
-            ghprbTargetBranch=liberty-12.2
 
 - job-template:
     name: "JJB-Misc-{name}"


### PR DESCRIPTION
These jobs are irelevant as they test aio build script which is being
migrated away from. They also cause confusion as they do not test JJB
jobs :(

These jobs also rely on the non-JJB RPC-AIO job which is being removed.

A new strategy is required for testing jjb jobs, but it will involve
having a dev jenkins master, possibly even in docker.

Connects rcbops/u-suk-dev#700