### PR TITLE
Push new links and os-releases to rpc-repo

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -474,6 +474,8 @@
 
                push "${{local_base}}/venvs/" "${{remote_base}}/venvs"
                push "${{local_base}}/pools/" "${{remote_base}}/pools"
+               push "${{local_base}}/os-releases/" "${{remote_base}}/os-releases"
+               push "${{local_base}}/links/" "${{remote_base}}/links"
 
                rm $key
       - archive:


### PR DESCRIPTION
When a successful build is completed, the 'links' and 'os-releases'
folder should be pushed up to rpc-repo so that the wheels that were
compiled may be re-used in future builds.

The 'links' folder is used as a simple index for pip during the
repo-build process. The subfolders in 'os-releases' are per-tag
simple indexes for pip to use when installing packages.

These folders contain links to the artifacts held in the 'pools'
folder, but the links provide access to them for their respective
uses.