### PR TITLE
Ensure that no unwanted leftovers are in the artifact repo

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -429,6 +429,7 @@
                push(){{
                  src="$1"
                  dest="$2"
+                 extra_args=${{3:-}}
                  description="$src to rpc-repo:$dest"
                  echo "===== Start: $description  ===="
                  [[ -d $src ]] || {{
@@ -436,6 +437,7 @@
                    exit
                  }}
                  rsync \
+                   ${{extra_args}} \
                    --delay-updates \
                    --recursive \
                    --links \
@@ -472,10 +474,16 @@
                echo "-----END RSA PRIVATE KEY-----" >> $key
                chmod 600 ${{key}}
 
-               push "${{local_base}}/venvs/" "${{remote_base}}/venvs"
+               # The following artifacts are purely additive - nothing must
+               # ever be deleted at the target.
                push "${{local_base}}/pools/" "${{remote_base}}/pools"
-               push "${{local_base}}/os-releases/" "${{remote_base}}/os-releases"
                push "${{local_base}}/links/" "${{remote_base}}/links"
+
+               # The following artifacts must be exactly as they look in the
+               # build when it completes. Anything that is on the target that
+               # is not in the build must be removed.
+               push "${{local_base}}/venvs/*" "${{remote_base}}/venvs/" "--delete"
+               push "${{local_base}}/os-releases/*" "${{remote_base}}/os-releases/" "--delete"
 
                rm $key
       - archive:


### PR DESCRIPTION
The artifacts stored after a successful build may execute multiple
times and it is possible that it may leave some parts behind which
are unnecessary or not applicable.

For example:
The os-releases folder in a build may refer to a newer version of
a python package which happens to not be pinned by OpenStack's
upper constraints. In the artifact copy the older version of the
package will still be linked in the tag's os-releases folder, thus
referncing two possible versions fot that tag. This, in turn, will
create problems when executing a build using these artifacts
because the wrong python package version may be used.

This patch ensures that the os-releases and venv folders produced
in the build are copied to rpc-repo exactly, but also ensures that
the folders for other tags are left alone.