### PR TITLE
Add Xenial support to the AIO Gate

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -27,6 +27,7 @@
     REPO_USER: "root"
     CRON: "H */6 * * *"
     KEEP_INSTANCE: "no"
+    IMAGE: "Ubuntu 14.04 LTS"
 
 #
 # Macros for repeated blocks
@@ -89,7 +90,6 @@
       - mitaka:
           branch: mitaka-13.1
           branches: "mitaka-.*"
-          UPGRADE_FROM_REF: "origin/liberty-12.2"
       - newton:
           branch: newton-14.0
           branches: "newton-.*"
@@ -108,6 +108,9 @@
             cinder_service_backup_program_enabled: true
       - upgrade:
           UPGRADE: "yes"
+      - xenial:
+          IMAGE: "Ubuntu 16.04 LTS"
+
     # NOTE: Hugh tested this and found that ztrigger overrides series and
     #       trigger doesn't, which is odd because both trigger and ztrigger
     #       sort after series.
@@ -118,25 +121,32 @@
       - periodic:
           branches: "do_not_build_on_pr"
     exclude:
+      - series: liberty
+        context: upgrade
       - series: newton
         context: upgrade
       - series: master
         context: upgrade
+
+      # Xenial builds are run for newton and above.
+      - series: liberty
+        context: xenial
+      - series: mitaka
+        context: xenial
     jobs:
       - 'JJB-RPC-AIO_{series}-{context}-{ztrigger}'
 
 - project:
-    name: 'JJB-AIO-Test-Jobs'
+    name: 'JJB-AIO-Experimental-Jobs'
     jobs:
       - 'JJB-RPC-AIO_{series}-{context}-{ztrigger}':
           series: mitaka-13.1
           branch: mitaka-13.1
           branches: "do_not_build_on_pr"
-          context: cidev
+          context: experimental
           ztrigger: ondemand
           DEPLOY_MAAS: "no"
-          USER_VARS: "maas_use_api: false"
-          JENKINS_RPC_BRANCH: "bug/353"
+          CRON: ""
 
 - project:
     name: 'JJB-Misc-Jobs'
@@ -177,7 +187,6 @@
 #
 
 - job-template:
-
     name: 'JJB-RPC-AIO_{series}-{context}-{ztrigger}'
     project-type: freestyle
     node: master
@@ -307,6 +316,10 @@
             When set to no, instance is deleted at the end of the job.
             Set to yes to prevent cleanup, for debug etc. Instance will be
             removed by the cleanup job after 48 hours.
+      - string:
+          name: IMAGE
+          default: "{IMAGE}"
+          description: "Pattern used to find an image to build the instance for the aio, defaults to 'Ubuntu 14.04 LTS'"
     properties:
       - rpc-openstack-github
     triggers:
@@ -341,7 +354,7 @@
             git checkout $JENKINS_RPC_BRANCH
             git reset --hard origin/$JENKINS_RPC_BRANCH
             . scripts/gating_bash_lib.sh
-            managed_aio
+            managed_aio "{IMAGE}"
     publishers:
       # archive artifacts - these are files (logs) that are transferred to the
       # jenkins master and are available after the build has completed

--- a/scripts/gating_bash_lib.sh
+++ b/scripts/gating_bash_lib.sh
@@ -69,6 +69,8 @@ managed_cleanup(){
 
 managed_aio(){
 
+  image="${1:-}"
+
   # need pip, novalcient and openstack client to boot the instance that
   # will contain the aio.
   #install_pip
@@ -84,7 +86,7 @@ managed_aio(){
                                  for(i=1; i<=NF; i++) c[i]=substr($i, 0, 1)}
                                  END{for(i=1; i<=length(c); i++)
                                  {print tolower(c[i]) }}' <<<$JOB_NAME)
-  get_instance "${short_job_name}-${BUILD_ID}"
+  get_instance "${short_job_name}-${BUILD_ID}" "${image}"
   on_remote clone_rpc "$sha1"
   on_remote aio
   deploy_result=$?
@@ -474,9 +476,10 @@ openrc_from_maas_vars(){
 get_instance(){
   . /opt/jenkins/venvs/osclients/bin/activate
   instance_name="${1}-${RANDOM}"
+  image_pattern="${2:-Ubuntu 14.04 LTS}"
   echo "Booting Instance: $instance_name" >&2
   flavor="performance2-15"
-  image="$(get_image 'Ubuntu 14.04 LTS')"
+  image="$(get_image "${image_pattern}")"
   key_name=jenkins
 
   for i in {1..3}


### PR DESCRIPTION
So far this adds the option of booting aio instances with an Xenial
image, it doesn't address any of the changes required for Xenial.

Connects rcbops/u-suk-dev#825