### PR TITLE
[WIP] Ensure resources survive an upgrade.

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -140,13 +140,16 @@
     name: 'JJB-AIO-Experimental-Jobs'
     jobs:
       - 'JJB-RPC-AIO_{series}-{context}-{ztrigger}':
-          series: mitaka-13.1
+          series: mitaka
           branch: mitaka-13.1
           branches: "do_not_build_on_pr"
           context: experimental
           ztrigger: ondemand
           DEPLOY_MAAS: "no"
           CRON: ""
+          UPGRADE: yes
+          UPGRADE_FROM_REF: "origin/liberty-12.2"
+          JENKINS_RPC_BRANCH: "bug/230"
 
 - project:
     name: 'JJB-Misc-Jobs'


### PR DESCRIPTION
This is a basic implementation of a check for resource status after an
upgrade.

A pair of instances are created before an upgrade,
then checked for existence and reachability after the upgrade.

Future improvement would be to measure the downtime of these instances
during the upgrade (using something like downtimer).

Connects rcbops/u-suk-dev#230