### PR TITLE
Create instance w/ correct name

### DIFF
--- a/scripts/gating_bash_lib.sh
+++ b/scripts/gating_bash_lib.sh
@@ -83,8 +83,8 @@ managed_aio(){
   short_job_name=$(awk -F'[-_]' '{ORS=""
                                  for(i=1; i<=NF; i++) c[i]=substr($i, 0, 1)}
                                  END{for(i=1; i<=length(c); i++)
-                                 {print c[i] }}' <<<$JOB_NAME)
-  get_instance "${short_job_name}_${BUILD_ID}"
+                                 {print tolower(c[i]) }}' <<<$JOB_NAME)
+  get_instance "${short_job_name}-${BUILD_ID}"
   on_remote clone_rpc "$sha1"
   on_remote aio
   deploy_result=$?
@@ -473,7 +473,7 @@ openrc_from_maas_vars(){
 
 get_instance(){
   . /opt/jenkins/venvs/osclients/bin/activate
-  instance_name="${1}_${RANDOM}"
+  instance_name="${1}-${RANDOM}"
   echo "Booting Instance: $instance_name" >&2
   flavor="performance2-15"
   image="$(get_image 'Ubuntu 14.04 LTS')"


### PR DESCRIPTION
Currently, when we spin up an instance, we give it a name such as
JRAmpm_7_13519.  However, when you log into the instance it has a
hostname of jrampm-7-13519.  The problem here is that when we go to
deploy maas, we look for an entity with label jrampm-7-13519 which does
not exist.

This commit simply changes how the instance name is formed so that it's
aligned with the hostname that the instance will have once it's booted.