### PR TITLE
Pass USER_VARS to instance and remove override

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -60,7 +60,6 @@
       - master:
           branch: master
           branches: "master"
-          USER_VARS: "maas_use_api: false"
     context:
       - swift
       - ceph:

--- a/scripts/gating_bash_lib.sh
+++ b/scripts/gating_bash_lib.sh
@@ -551,6 +551,7 @@ on_remote(){
     TEMPEST_TESTS
     JENKINS_RPC_REPO
     JENKINS_RPC_BRANCH
+    USER_VARS
     rackspace_cloud_api_key
     rackspace_cloud_auth_url
     rackspace_cloud_password


### PR DESCRIPTION
This commit does the following:

1. Adds USER_VARS environment variable to ship_env_keys in
   scripts/gating_bash_lib.sh so that USER_VARS are correctly shipped
   to the gating instances.
2. Removes `maas_use_api: false` from USER_VARS from master series
   since a) DEPLOY_MAAS already defaults to "no" and b) when we run
   the JJB-AIO-MAAS-Job job we want maas to be tested entirely, not
   with api checks being disabled. Side note, if we override USER_VARS
   in the series and the context as was previously taking place, does
   one win over the other or do these get merged somehow?

Connects https://github.com/rcbops/u-suk-dev/issues/919