### PR TITLE
Reuse existing secret for SSH key

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -668,7 +668,7 @@
       - timestamps
       - credentials-binding:
         - file:
-            credential-id: REPO_SSH_SECRET_FILE
+            credential-id: RPC_REPO_KEY_FILE
             variable: REPO_KEY
         - file:
             credential-id: REPO_GPG_SECRET_FILE


### PR DESCRIPTION
SSH Key file is already a stored secret, so we should reuse it in
apt artifacts, instead of having another one.