### PR TITLE
Replace rpc_release derivation with a lookup

### DIFF
--- a/scripts/test_holland.yml
+++ b/scripts/test_holland.yml
@@ -3,18 +3,11 @@
 - hosts: galera
   user: root
   vars:
+    rpc_release: "{{ lookup('pipe', 'cd /opt/rpc-openstack && git describe --tags --abbrev=0') }}"
     holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
   tasks:
-    - name: Discover rpc-openstack version
-      git_repo_info:
-        path: "/opt/rpc-openstack"
-      delegate_to: localhost
-      run_once: true
-      tags:
-        - rpc-release
-    
     - name: Test for holland venv
-      stat: 
+      stat:
         path: "{{ holland_venv_bin }}"
       register: holland_venv
 


### PR DESCRIPTION
The current mechanism to derive the rpc_release uses a module
and a task. This patch replaces it with a simpler lookup.

This mechanism is more generic, has no other dependencies, and
will work with all versions of RPC.