### PR TITLE
Update AIO Cleanup script

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -1,3 +1,34 @@
+
+# defaults - These must be set as the default value of a jenkins parameter in order to be injected into the build Environment.
+- defaults:
+    name: global
+    RPC_REPO: "https://github.com/rcbops/rpc-openstack"
+    TEMPEST_TESTS: "scenario heat_api cinder_backup defcore"
+    DEPLOY_CEPH: "no"
+    DEPLOY_SWIFT: "yes"
+    DEPLOY_MAAS: "yes"
+    USER_VARS: ""
+    UPGRADE: "no"
+    UPGRADE_FROM_REF: "origin/kilo"
+    UPGRADE_FROM_NEAREST_TAG: "yes"
+    UPGRADE_TYPE: "major"
+    UBUNTU_REPO: "http://mirror.rackspace.com/ubuntu"
+    JENKINS_RPC_REPO: "https://github.com/rcbops/jenkins-rpc"
+    JENKINS_RPC_BRANCH: "master"
+    BUILD_SCRIPT_PATH: "scripts/aio_build_script.sh"
+    # Override the OSA submodule?
+    OA_REPO: "none"
+    OA_BRANCH: ""
+    # branch for periodics to build
+    branch: master
+    # PRs targetting branches that match this pattern will be tested with this job
+    branches: "kilo|liberty-.*|mitaka-.*|master"
+    REPO_HOST: "23.253.158.148"
+    REPO_USER: "root"
+    CRON: "H */6 * * *"
+    KEEP_INSTANCE: "no"
+
+#
 # Macros for repeated blocks
 
 # Define the github project associated with jenkins rpc
@@ -17,11 +48,15 @@
     name: jenkins-rpc-git
     scm:
       - git:
-          url: https://github.com/rcbops/jenkins-rpc
+          url: "$JENKINS_RPC_REPO"
           branches:
-            - master
+            - "$JENKINS_RPC_BRANCH"
           refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
           name: origin
+
+# Note: JJB Macros are not expanded in macros, even if that macro is used in a
+# template.  so any parameters that have jjb vars as defaults can't be defined
+# in a macro :(
 
 - parameter:
     name: pr-params
@@ -142,32 +177,6 @@
 #
 
 - job-template:
-    # defaults - These must be set as the default value of a jenkins parameter in order to be injected into the build Environment.
-    RPC_REPO: "https://github.com/rcbops/rpc-openstack"
-    TEMPEST_TESTS: "scenario heat_api cinder_backup defcore"
-    DEPLOY_CEPH: "no"
-    DEPLOY_SWIFT: "yes"
-    DEPLOY_MAAS: "yes"
-    USER_VARS: ""
-    UPGRADE: "no"
-    UPGRADE_FROM_REF: "origin/kilo"
-    UPGRADE_FROM_NEAREST_TAG: "yes"
-    UPGRADE_TYPE: "major"
-    UBUNTU_REPO: "http://mirror.rackspace.com/ubuntu"
-    JENKINS_RPC_REPO: "https://github.com/rcbops/jenkins-rpc"
-    JENKINS_RPC_BRANCH: "master"
-    BUILD_SCRIPT_PATH: "scripts/aio_build_script.sh"
-    # Override the OSA submodule?
-    OA_REPO: "none"
-    OA_BRANCH: ""
-    # branch for periodics to build
-    branch: master
-    # PRs targetting branches that match this pattern will be tested with this job
-    branches: "kilo|liberty-.*|mitaka-.*|master"
-    REPO_HOST: "23.253.158.148"
-    REPO_USER: "root"
-    CRON: "H */6 * * *"
-    KEEP_INSTANCE: "no"
 
     name: 'JJB-RPC-AIO_{series}-{context}-{ztrigger}'
     project-type: freestyle
@@ -214,6 +223,14 @@
 
     parameters:
       - pr-params
+      - string:
+          name: JENKINS_RPC_REPO
+          default: "{JENKINS_RPC_REPO}"
+          description: "Repo url for JENKINS_RPC"
+      - string:
+          name: JENKINS_RPC_BRANCH
+          default: "{JENKINS_RPC_BRANCH}"
+          description: "Branch to checkout for JENKINS_RPC"
       - string:
           name: ghprbTargetBranch
           default: "{branch}"
@@ -272,14 +289,6 @@
           default: "{UBUNTU_REPO}"
           description: "Ubuntu repo to use, currently requires all sections so not compatible with OS infra mirrors"
       - string:
-          name: JENKINS_RPC_REPO
-          default: "{JENKINS_RPC_REPO}"
-          description: "Repo url for JENKINS_RPC"
-      - string:
-          name: JENKINS_RPC_BRANCH
-          default: "{JENKINS_RPC_BRANCH}"
-          description: "Branch to checkout for JENKINS_RPC"
-      - string:
           name: BUILD_SCRIPT_PATH
           default: "{BUILD_SCRIPT_PATH}"
           description: "Path to the build script within JENKINS_RPC_REPO"
@@ -296,8 +305,8 @@
           default: "{KEEP_INSTANCE}"
           description: |
             When set to no, instance is deleted at the end of the job.
-            Set to yes to prevent cleanup, for debug etc. Instance may still
-            get cleaned up by another cleanup job.
+            Set to yes to prevent cleanup, for debug etc. Instance will be
+            removed by the cleanup job after 48 hours.
     properties:
       - rpc-openstack-github
     triggers:
@@ -453,6 +462,15 @@
     node: master
     logrotate:
       numToKeep: 50
+    parameters:
+      - string:
+          name: JENKINS_RPC_REPO
+          default: "{JENKINS_RPC_REPO}"
+          description: "Repo url for JENKINS_RPC"
+      - string:
+          name: JENKINS_RPC_BRANCH
+          default: "{JENKINS_RPC_BRANCH}"
+          description: "Branch to checkout for JENKINS_RPC"
     # NOTE(mattt): Is this property actually required here?
     properties:
       - jenkins-rpc-github
@@ -479,6 +497,15 @@
     node: master
     logrotate:
       daysToKeep: 30
+    parameters:
+      - string:
+          name: JENKINS_RPC_REPO
+          default: "{JENKINS_RPC_REPO}"
+          description: "Repo url for JENKINS_RPC"
+      - string:
+          name: JENKINS_RPC_BRANCH
+          default: "{JENKINS_RPC_BRANCH}"
+          description: "Branch to checkout for JENKINS_RPC"
     properties:
       - jenkins-rpc-github
     scm:
@@ -503,18 +530,21 @@
     parameters:
       - pr-params
       - string:
+          name: JENKINS_RPC_REPO
+          default: "{JENKINS_RPC_REPO}"
+          description: "Repo url for JENKINS_RPC"
+      - string:
+          name: JENKINS_RPC_BRANCH
+          default: "{JENKINS_RPC_BRANCH}"
+          description: "Branch to checkout for JENKINS_RPC"
+      - string:
           name: ghprbTargetBranch
           default: "master"
       - string:
           name: sha1
           default: "master"
     scm:
-      - git:
-          url: https://github.com/rcbops/jenkins-rpc
-          branches:
-            - "${sha1}"
-          refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
-          name: origin
+      - jenkins-rpc-git
     triggers:
       - github-pull-request:
           admin-list:

--- a/scripts/aio_cleanup.py
+++ b/scripts/aio_cleanup.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
+# This script deletes instances whose name starts with "jra" if they are in
+# error state or older than 48hrs.
+
 import datetime
 import dateutil.parser
 import os
-import requests
 
 from novaclient import client
 
@@ -16,47 +18,18 @@ nova = client.Client(
     region_name="IAD"
 )
 
-jenkins_api_user = os.environ['JENKINS_API_USER']
-jenkins_api_pass = os.environ['JENKINS_API_PASS']
-
-slaves = requests.get("http://jenkins.propter.net/computer/api/json",
-                      auth=(jenkins_api_user, jenkins_api_pass)).json()['computer']
-slave_names = [x['displayName'] for x in slaves]
-print("Jenkins Slaves: %s" %slave_names)
-def jenkins_node(name):
-  return name in slave_names
-
-
-slaves=0
-instances=0
 for s in nova.servers.list():
     created = dateutil.parser.parse(s.created)
-    sixhoursago = datetime.datetime.now(created.tzinfo)-datetime.timedelta(hours=6)
-    comingofage = datetime.datetime.now(created.tzinfo)-datetime.timedelta(minutes=7)
-    adult = created < comingofage
+    old_threshold = datetime.datetime.now(
+        created.tzinfo)-datetime.timedelta(hours=48)
     error = s.status == 'ERROR'
-    old = created < sixhoursago
-    is_slave = jenkins_node(s.name)
-    instances+=1
-    if is_slave:
-        slaves+=1
-    print("Instance:{name} slave:{slave} status:{status} adult:{adult} old:{old}".format(
+    old = created < old_threshold
+    print("Instance:{name} status:{status} old:{old}".format(
         name=s.name,
-        slave=is_slave,
         status=s.status,
-        adult=adult,
         old=old
     ))
-    if (s.name.startswith('jrpcaio')
-            and (
-                s.status == 'ERROR'
-                or ((not is_slave) and adult)
-                or old
-            )):
-        print("Deleting %(name)s Error:%(error)s Old:%(old)s"
-              % dict(name=s.name, error=error, old=old))
+    if (s.name.startswith('jra') and (error or old)):
+        print("Deleting {name} Error:{error} Old:{old}".format(
+            name=s.name, error=error, old=old))
         s.delete()
-
-print("Slaves: {numslaves}, Instances that aren't active slaves: {non_slave_instances}".format(
-    numslaves=slaves,
-    non_slave_instances=instances-slaves))


### PR DESCRIPTION
The AIO cleanup script now reflects our curent AIO deployment naming and
methodology. Logic related to jenkins slave status has been removed
because job instances are no longer registerd as slaves.

The old threshold has been increased to 48 hours so that if a job is run
with keep_instance then the requester has two days to use the instance
for deugging before its removed.

Also:
 * moves AIO template defaults into a global defaults object
 * Adds parameters to the jenkins-rpc-git macro

Connects rcbops/u-suk-dev#953