### PR TITLE
Fail on first error in apt artifacts

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -688,6 +688,8 @@
     builders:
       - shell: |
           #!/bin/bash
+          set -e
+          set -o pipefail
           #git clone ${RPC_ARTIFACTS} rpc-artifacts
           #cd rpc-artifacts
           mkdir -p ~/.ssh/


### PR DESCRIPTION
If error happens, the build should fail immediately. This wasn't
done for apt artifacts.