### PR TITLE
Fix list of builded rpc artifacts

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -740,7 +740,7 @@
           echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='~/.ssh/repo.key' " >> inventory
           ansible-playbook aptly-pre-install.yml ${ANSIBLE_VERBOSITY}
           ansible-playbook aptly-all.yml -i inventory ${ANSIBLE_VERBOSITY}
-          ls -R /openstack/
+          ls -R ${RPC_ARTIFACTS_FOLDER}
 
 - job:
     name: JJB-Upgrade-Matrix


### PR DESCRIPTION
The builded RPC artifacts are not residing in /openstack anymore,
but follows a variable instead.