### PR TITLE
Add global defaults to JJB-Job-Test

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -518,6 +518,7 @@
 
 - job:
     name: JJB-Job-Test
+    defaults: global
     project-type: freestyle
     description: "Test JJB job defintions for syntax"
     disabled: false


### PR DESCRIPTION
This commit adds the global defaults to the JJB-Job-Test job so that it
can properly resolve JENKINS_RPC_REPO and JENKINS_RPC_BRANCH.