### PR TITLE
Remove template vars from non-template jobs

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -500,11 +500,11 @@
     parameters:
       - string:
           name: JENKINS_RPC_REPO
-          default: "{JENKINS_RPC_REPO}"
+          default: "https://github.com/rcbops/jenkins-rpc"
           description: "Repo url for JENKINS_RPC"
       - string:
           name: JENKINS_RPC_BRANCH
-          default: "{JENKINS_RPC_BRANCH}"
+          default: "master"
           description: "Branch to checkout for JENKINS_RPC"
     properties:
       - jenkins-rpc-github
@@ -531,11 +531,11 @@
       - pr-params
       - string:
           name: JENKINS_RPC_REPO
-          default: "{JENKINS_RPC_REPO}"
+          default: "https://github.com/rcbops/jenkins-rpc"
           description: "Repo url for JENKINS_RPC"
       - string:
           name: JENKINS_RPC_BRANCH
-          default: "{JENKINS_RPC_BRANCH}"
+          default: "master"
           description: "Branch to checkout for JENKINS_RPC"
       - string:
           name: ghprbTargetBranch


### PR DESCRIPTION
Template vars are only processed in job templates and projects, not in
standalone jobs.

Connects rcbops/u-suk-dev#975