### PR TITLE
Delete old jobs when updating JJB Jobs

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -519,6 +519,12 @@
           name: JENKINS_RPC_BRANCH
           default: "master"
           description: "Branch to checkout for JENKINS_RPC"
+      - string:
+          name: PURGE_OLD_JOBS
+          default: yes
+          description: |
+            Auto remove obsolete jobs. Useful when jobs are removed from
+            jobs.yaml or are renamed. yes/no
     properties:
       - jenkins-rpc-github
     scm:

--- a/scripts/run_jjb.sh
+++ b/scripts/run_jjb.sh
@@ -12,6 +12,11 @@ set -u
 
 pushd rpc-jobs
 
+if [ "${PURGE_OLD_JOBS:-}" == "yes" ] && [ $OPERATION == "update" ]
+then
+  DELETE_OLD = "--delete-old"
+fi
+
 # get operation
 OPERATION=${1:-update}
 [[ $# -gt 0 ]] && shift
@@ -24,6 +29,7 @@ jenkins-jobs \
   --conf jenkins_jobs.ini \
   --password $JENKINS_API_KEY \
   $OPERATION \
+  ${DELETE_OLD:-} \
   jobs.yaml \
   $@
 


### PR DESCRIPTION
This job ensures that obsolete jobs are not left on the jenkins master
when jobs are removed or renamed.

Connects rcbops/u-suk-dev#981