### PR TITLE
Fix SCM references in JJB test/update jobs

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -516,23 +516,36 @@
           default: "https://github.com/rcbops/jenkins-rpc"
           description: "Repo url for JENKINS_RPC"
       - string:
-          name: JENKINS_RPC_BRANCH
+          name: sha1
           default: "master"
-          description: "Branch to checkout for JENKINS_RPC"
+          description: |
+            branch/sha of jenkins-rpc to be tested.
       - string:
           name: PURGE_OLD_JOBS
-          default: yes
+          default: "yes"
           description: |
             Auto remove obsolete jobs. Useful when jobs are removed from
             jobs.yaml or are renamed. yes/no
     properties:
       - jenkins-rpc-github
+    wrappers:
+      - credentials-binding:
+        - text:
+            credential-id: JJB_JENKINS_ACCOUNT
+            variable: JJB_JENKINS_ACCOUNT
     scm:
-      - jenkins-rpc-git
+      - git:
+          url: "$JENKINS_RPC_REPO"
+          branches:
+            - "$sha1"
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
+          name: origin
     triggers:
       - github # triggered post merge, not on PR
     builders:
-      - shell: scripts/run_jjb.sh update
+      - shell: |
+          git show HEAD
+          scripts/run_jjb.sh update
 
 
 - job:
@@ -547,23 +560,27 @@
     properties:
       - jenkins-rpc-github
     parameters:
-      - pr-params
       - string:
           name: JENKINS_RPC_REPO
           default: "https://github.com/rcbops/jenkins-rpc"
           description: "Repo url for JENKINS_RPC"
       - string:
-          name: JENKINS_RPC_BRANCH
-          default: "master"
-          description: "Branch to checkout for JENKINS_RPC"
-      - string:
-          name: ghprbTargetBranch
-          default: "master"
-      - string:
           name: sha1
           default: "master"
+          description: |
+            branch/sha of jenkins-rpc to be tested.
+    wrappers:
+      - credentials-binding:
+        - text:
+            credential-id: JJB_JENKINS_ACCOUNT
+            variable: JJB_JENKINS_ACCOUNT
     scm:
-      - jenkins-rpc-git
+      - git:
+          url: "$JENKINS_RPC_REPO"
+          branches:
+            - "$sha1"
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*"
+          name: origin
     triggers:
       - github-pull-request:
           admin-list:
@@ -580,7 +597,9 @@
           auth-id: "8b635975-7d59-45f8-b7ee-8bceb2e44ba3"
           status-context: 'JJB-Test'
     builders:
-      - shell: scripts/run_jjb.sh test
+      - shell: |
+          git show HEAD
+          scripts/run_jjb.sh test
 
 - job:
     name: JJB-RPC-Training-Multinode

--- a/scripts/run_jjb.sh
+++ b/scripts/run_jjb.sh
@@ -12,14 +12,14 @@ set -u
 
 pushd rpc-jobs
 
-if [ "${PURGE_OLD_JOBS:-}" == "yes" ] && [ $OPERATION == "update" ]
-then
-  DELETE_OLD = "--delete-old"
-fi
-
 # get operation
 OPERATION=${1:-update}
 [[ $# -gt 0 ]] && shift
+
+if [ "${PURGE_OLD_JOBS:-}" == "yes" ] && [ $OPERATION == "update" ]
+then
+  DELETE_OLD="--delete-old"
+fi
 
 # any remaining paramters are specific jobs to update, if none are specified
 # all jobs will be updated


### PR DESCRIPTION
These were broken in an attempt to use a macro for scm configuration, however that macro was for jobs that use jenkins-rpc as a secondary repo, not the one which is checked out with the changes to be tested. 

Also 
  * fixes a "yes" that should have been quoted to avoid autoboolification
  * Adds a git show HEAD so that the correct commit can be verified. The commit that's checkout out is the merge commit from the PR branch, which doesn't match the actual commit at the tip of the PR branch.                                                                                                                                                                                                  

Connects rcbos/u-suk-dev#981