### PR TITLE
Ensure apt artifacts do not build concurrently

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -692,9 +692,9 @@
           allow-empty-results: true
 
 - job:
-    name: JJB-apt-artifacts
-    node: artifcats
-    concurrent: true
+    name: JJB-artifacts-apt
+    node: ArtifactBuilder
+    concurrent: false
     build-discarder:
       daysToKeep: 30
     triggers:


### PR DESCRIPTION
This patch does the following:

- corrects the node name
- ensures that the job cannot run more than once at the
  same time
- renames the job so that all artifact jobs start with
  JJB-artifact-*