### PR TITLE
Re-enable MaaS tests in Jenkins

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -117,7 +117,7 @@
     ztrigger:
       - pr:
           CRON: ""
-          DEPLOY_MAAS: "no"
+          USER_VARS: "maas_use_api: false"
       - periodic:
           branches: "do_not_build_on_pr"
     exclude:


### PR DESCRIPTION
Now that lots of work is underway in rcbops/u-suk-dev#948 to
improve MaaS, we should re-enable the tests in Jenkins.