### PR TITLE
Change periodic trigger time

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -25,7 +25,7 @@
     branches: "liberty-.*|mitaka-.*|newton-.*|master"
     REPO_HOST: "23.253.158.148"
     REPO_USER: "root"
-    CRON: "H */6 * * *"
+    CRON: "H H(9-21) * * 1-5"
     KEEP_INSTANCE: "no"
     IMAGE: "Ubuntu 14.04 LTS"
 


### PR DESCRIPTION
Currently, all periodics are triggered every 6 hours.  This commit
updates the default schedule to trigger jobs once between 9 AM and
9 PM UTC (giving us reasonable coverage across UK and US shifts),
and only runs them on week days.

The intent here is to run the periodics less frequently, allowing us to
pay more attention to failures and be quicker to respond to issues.