### PR TITLE
Allow the destruction of apt artifacts

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -731,6 +731,10 @@
           name: RPC_ARTIFACTS_PUBLIC_FOLDER
           default: "/var/www/repo"
           description: "Folder to store artifacts (public)"
+      - string:
+          name: RECREATE_SNAPSHOTS
+          default: "NO"
+          description: "Set this to YES to destroy existing snapshot for the current artifact version"
     wrappers:
       - ansicolor
       - timestamps


### PR DESCRIPTION
Currently if the job re-runs, the apt artifacts for the same build
number will not be created again (on purpose). We want to have
the feature to override this in the CI. The code in rpc-artifacts
was done, but no wiring existed in jenkins. This should fix it.