### PR TITLE
Add python artifact generation job

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -28,6 +28,7 @@
     CRON: "H H(9-21) * * 1-5"
     KEEP_INSTANCE: "no"
     IMAGE: "Ubuntu 14.04 LTS"
+    BUILD_SCRIPT_FUNCTION: "managed_aio"
 
 #
 # Macros for repeated blocks
@@ -179,6 +180,22 @@
             set -e
             bash scripts/heat_cleanup.sh
 
+- project:
+    name: 'JJB-artifacts-python'
+    series:
+      - master:
+          branch: master
+          branches: master
+      - newton:
+          branch: newton-14.0
+          branches: "newton-.*"
+    jobs:
+      - 'JJB-RPC-AIO_{series}-{context}-{ztrigger}':
+          context: experimental
+          ztrigger: ondemand
+          DEPLOY_MAAS: "no"
+          CRON: ""
+          BUILD_SCRIPT_FUNCTION: managed_aio_artifacts
 
 ## Job Definitions
 # This template is for testing PRs against Jenkins-RPC
@@ -302,6 +319,10 @@
           default: "{BUILD_SCRIPT_PATH}"
           description: "Path to the build script within JENKINS_RPC_REPO"
       - string:
+          name: BUILD_SCRIPT_FUNCTION
+          default: "{BUILD_SCRIPT_FUNCTION}"
+          description: "The name of the build function within JENKINS_RPC_REPO"
+      - string:
           name: OA_REPO
           default: "{OA_REPO}"
           description: "Openstack Ansible Repo - can be used to override the RPC OSA submodule"
@@ -354,7 +375,7 @@
             git checkout $JENKINS_RPC_BRANCH
             git reset --hard origin/$JENKINS_RPC_BRANCH
             . scripts/gating_bash_lib.sh
-            managed_aio "{IMAGE}"
+            $BUILD_SCRIPT_FUNCTION "$IMAGE"
     publishers:
       # archive artifacts - these are files (logs) that are transferred to the
       # jenkins master and are available after the build has completed

--- a/scripts/gating_bash_lib.sh
+++ b/scripts/gating_bash_lib.sh
@@ -103,6 +103,43 @@ aio(){
   return $deploy_result
 }
 
+managed_aio_artifacts(){
+
+  image="${1:-}"
+
+  # need pip, novalcient and openstack client to boot the instance that
+  # will contain the aio.
+  #install_pip
+  #pip install python-novaclient python-openstackclient
+
+  # managed_cleanup is now called as a seperate shell step.
+  trap abort SIGHUP SIGINT SIGTERM
+  openrc_from_maas_vars
+  # reduce job name to first character of each word
+  # eg jjb-ugprade-matrix --> jum
+  # This is to avoid hitting the container name limit
+  short_job_name=$(awk -F'[-_]' '{ORS=""
+                                 for(i=1; i<=NF; i++) c[i]=substr($i, 0, 1)}
+                                 END{for(i=1; i<=length(c); i++)
+                                 {print tolower(c[i]) }}' <<<$JOB_NAME)
+  get_instance "${short_job_name}-${BUILD_ID}" "${image}"
+  on_remote clone_rpc "$sha1"
+  on_remote aio_artifact_build
+  deploy_result=$?
+  # work out working dir on remote, for executing stuff and collecting artefacts
+  return $deploy_result
+  # teardown called by exit handler
+}
+
+aio_artifact_build(){
+  prep
+  export TERM=linux
+  sudo -E git clone https://github.com/rcbops/rpc-artifacts.git /opt/rpc-artifacts
+  sudo -E /opt/artifacts/build-python-artifacts.sh
+  deploy_result=$?
+  return $deploy_result
+}
+
 prep(){
   skip_if_doc_only
   check_for_existing_config


### PR DESCRIPTION
This patch adds some moving parts to the scripts library
and adjusts the AIO job template to be able to use it
for the building of python artifacts.

A future additional job will use a similar mechanism to
build container artifacts.

Connects https://github.com/rcbops/u-suk-dev/issues/1020