### PR TITLE
Add REPO env vars to AIO jobs

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -346,6 +346,14 @@
           name: IMAGE
           default: "{IMAGE}"
           description: "Pattern used to find an image to build the instance for the aio, defaults to 'Ubuntu 14.04 LTS'"
+      - string:
+          name: REPO_USER
+          default: "{REPO_USER}"
+          description: "The user account for write access to rpc-repo"
+      - string:
+          name: REPO_HOST
+          default: "{REPO_HOST}"
+          description: "The host address for rpc-repo"
     properties:
       - rpc-openstack-github
     triggers:

--- a/scripts/gating_bash_lib.sh
+++ b/scripts/gating_bash_lib.sh
@@ -597,6 +597,9 @@ on_remote(){
     rackspace_cloud_password
     rackspace_cloud_tenant_id
     rackspace_cloud_username
+    REPO_KEY
+    REPO_HOST
+    REPO_USER
   )
 
   #Dump env vars which will be required on the remote host


### PR DESCRIPTION
In order to allow the AIO's to publish to rpc-repo,
we need to be able to use the env vars which inform
the AIO of the key, user and repo address.

Connects https://github.com/rcbops/u-suk-dev/issues/1094