### PR TITLE
[WIP] Provide a default for RPC_REPO

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -818,7 +818,7 @@
           description: "RPC-Artifacts Git Repository"
       - string:
           name: RPC_REPO
-          default: "{RPC_REPO}"
+          default: "https://github.com/rcbops/rpc-openstack"
           description: "RPC REPO URL"
       - string:
           name: RPC_REPO_BRANCH


### PR DESCRIPTION
For the git artifacts job, the substitution for RPC_REPO
isn't working. Considering that this is a low impact
issue, it's simpler to just provide a default value
than to try and figure out what's going on in a system
that's about to be replaced.

Connects https://github.com/rcbops/u-suk-dev/issues/1111