### PR TITLE
Ensure that the plugins path is set when executing

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -885,7 +885,8 @@
           # Append rpc-repo host to [mirrors] group
           echo "repo ansible_host=${REPO_HOST} ansible_user=${REPO_USER} ansible_ssh_private_key_file='~/.ssh/repo.key' " >> /opt/rpc-artifacts/inventory
           # Fetch all the git repositories, then push them to rpc-repo
-          ansible-playbook /opt/rpc-artifacts/openstackgit-update.yml -i /opt/rpc-artifacts/inventory -vv
+          # The openstack-ansible CLI is used to ensure that the library path is set
+          openstack-ansible /opt/rpc-artifacts/openstackgit-update.yml -i /opt/rpc-artifacts/inventory -vv
 
 - job:
     name: JJB-Upgrade-Matrix


### PR DESCRIPTION
If using the ansible-playbook CLI the openstack-ansible
wrapper does not set any library paths or anything. Using
the openstack-ansible CLI always forces the use of the
plugins.

This patch ensures that we have access to the py_pkgs
lookup when executing the job.

https://github.com/rcbops/u-suk-dev/issues/1111