### PR TITLE
Move python artifact job to use rpc-o repo

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -183,15 +183,10 @@
 - project:
     name: 'JJB-artifacts-python'
     series:
-      - master_trusty:
-          branch: master
-      - master_xenial:
-          branch: master
-          IMAGE: "Ubuntu 16.04 LTS"
       - newton_trusty:
-          branch: newton-14.0
+          branch: artifacts-14.0
       - newton_xenial:
-          branch: newton-14.0
+          branch: artifacts-14.0
           IMAGE: "Ubuntu 16.04 LTS"
     jobs:
       - 'JJB-RPC-AIO_{series}-{context}-{ztrigger}':

--- a/scripts/gating_bash_lib.sh
+++ b/scripts/gating_bash_lib.sh
@@ -134,8 +134,7 @@ managed_aio_artifacts(){
 aio_artifact_build(){
   prep
   export TERM=linux
-  sudo -E git clone https://github.com/rcbops/rpc-artifacts.git /opt/rpc-artifacts
-  sudo -E /opt/rpc-artifacts/build-python-artifacts.sh
+  sudo -E /opt/rpc-openstack/scripts/artifacts-building/python/build-python-artifacts.sh
   deploy_result=$?
   return $deploy_result
 }


### PR DESCRIPTION
Previously the rpc-artifacts repository was used. Now
the rpc-openstack repository is used instead.

As the scripts are not available in any branch except
the 'artifacts-14.0' branch, the job is set to only
be available on that branch.

Connects https://github.com/rcbops/u-suk-dev/issues/1132