### PR TITLE
[WIP] Test lvm and ceph backends when ceph deployed

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -107,6 +107,9 @@
                     default_volume_type: ceph
             cinder_service_backup_driver: cinder.backup.drivers.ceph
             cinder_service_backup_program_enabled: true
+            tempest_volume_multi_backend_enabled: true
+            tempest_volume_backend_names: [ LVM_iSCSI, ceph ]
+          TEMPEST_TESTS: "scenario heat_api cinder_backup cinder_multi_backend defcore"
       - upgrade:
           UPGRADE: "yes"
       - xenial:


### PR DESCRIPTION
This commit makes some tempest-related overrides such that tempest will
test both ceph and lvm backends when ceph is deployed.  This necessary
as we recently had an issue with cinder-volume not being able to speak
to the ceph cluster which went largely undetected.