### PR TITLE
Disable master jobs

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -94,9 +94,6 @@
       - newton:
           branch: newton-14.0
           branches: "newton-.*"
-      - master:
-          branch: master
-          branches: "master"
     context:
       - swift
       - ceph:
@@ -125,8 +122,6 @@
       - series: liberty
         context: upgrade
       - series: newton
-        context: upgrade
-      - series: master
         context: upgrade
 
       # Xenial builds are run for newton and above.


### PR DESCRIPTION
The first jobs to transition to CIT jenkins are the master jobs,
this commit removes them from jenkins-rpc.

Its important this is not merged before rcbops/rpc-openstack#1991

Connects rcbops/u-suk-dev#1313