### PR TITLE
Move artifact building to larger node

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -739,7 +739,7 @@
 
 - job:
     name: JJB-artifacts-apt
-    node: ArtifactBuilder
+    node: ArtifactBuilder2
     concurrent: false
     build-discarder:
       daysToKeep: 30


### PR DESCRIPTION
APT Artifact building fails with OOM issues since the inclusion
of updates and backport repo [1]

This should make life a little better.

[1]: https://gist.github.com/evrardjp/3f81e247df9f0821f882dd73146b20b9