### PR TITLE
Add flippable sections for apt artifact builds

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -778,9 +778,21 @@
           default: "/var/www/repo"
           description: "Folder to store artifacts (public)"
       - string:
+          name: DOWNLOAD_FIRST
+          default: "YES"
+          description: "Set this to NO if you don't want to fetch existing rpc mirror data -- corrupted data, or want to start fresh."
+      - string:
           name: RECREATE_SNAPSHOTS
           default: "NO"
           description: "Set this to YES to destroy existing snapshot for the current artifact version"
+      - string:
+          name: PUBLISH_SNAPSHOTS
+          default: "YES"
+          description: "Set this to NO if you don't want to publish the snapshots into local folder."
+      - string:
+          name: PUSH_TO_MIRROR
+          default: "YES"
+          description: "Set this to NO if you don't want to push the published local folder, the public gpg key, and the current db to the rpc mirror."
     wrappers:
       - ansicolor
       - timestamps


### PR DESCRIPTION
The apt artifact building can now make use of different booleans:
- DOWNLOAD_FIRST
- PUBLISH_SNAPSHOT
- PUSH_TO_MIRROR
to change the job behavior.

This brings the modularity into jenkins, for manual job building.