### PR TITLE
Override ceph_stable_release

### DIFF
--- a/rpc-jobs/jobs.yaml
+++ b/rpc-jobs/jobs.yaml
@@ -102,6 +102,7 @@
       - ceph:
           DEPLOY_CEPH: "yes"
           USER_VARS: |
+            ceph_stable_version: "hammer"
             cinder_cinder_conf_overrides:
                 DEFAULT:
                     default_volume_type: ceph


### PR DESCRIPTION
This variable is on it's way to changing to jewel in RPCO,
see rcbops/rpc-openstack#2117. However,
the newton+trusty+ceph job currently deploys hammer, and we will
like to keep it that way. This commit overrides ceph_stable_release
to hammer.

Connects rcbops/u-suk-dev#1536